### PR TITLE
Feat: Add changes log to login (#33)

### DIFF
--- a/app/Modules/Auth/Controllers/AuthenticatedSessionController.php
+++ b/app/Modules/Auth/Controllers/AuthenticatedSessionController.php
@@ -18,7 +18,9 @@ class AuthenticatedSessionController extends Controller
      */
     public function create(): Response
     {
-        return Inertia::render('Auth/Login');
+        return Inertia::render('Auth/Login', [
+            'changelog' => config('changelog.releases.0'),
+        ]);
     }
 
     /**

--- a/config/changelog.php
+++ b/config/changelog.php
@@ -1,0 +1,25 @@
+<?php
+
+return [
+    'releases' => [
+        [
+            'version' => '2.0.6',
+            'status' => 'In development',
+            'released_at' => null,
+            'changes' => [
+                [
+                    'category' => 'Changed',
+                    'description' => 'Restored ID-based links for planning and expense pages.',
+                ],
+                [
+                    'category' => 'Security',
+                    'description' => 'Updated application dependencies and pinned local service versions.',
+                ],
+                [
+                    'category' => 'Added',
+                    'description' => 'Added a public changes summary to the login page.',
+                ],
+            ],
+        ],
+    ],
+];

--- a/resources/js/Pages/Auth/Login.tsx
+++ b/resources/js/Pages/Auth/Login.tsx
@@ -3,7 +3,23 @@ import { Head, Link, useForm } from '@inertiajs/react';
 import GuestLayout from '@/Layouts/GuestLayout';
 import { route } from '@/utils/route';
 
-export default function Login() {
+interface ChangelogChange {
+    category: string;
+    description: string;
+}
+
+interface ChangelogRelease {
+    version: string;
+    status: string;
+    released_at: string | null;
+    changes: ChangelogChange[];
+}
+
+interface LoginProps {
+    changelog: ChangelogRelease | null;
+}
+
+export default function Login({ changelog }: LoginProps) {
     const { data, setData, post, processing, errors } = useForm({
         email: '',
         password: '',
@@ -87,6 +103,39 @@ export default function Login() {
                     </Link>
                 </div>
             </form>
+
+            {changelog && (
+                <section
+                    aria-labelledby="changelog-heading"
+                    className="mt-6 border-t border-gray-200 pt-5 dark:border-gray-700"
+                >
+                    <div className="flex flex-wrap items-baseline justify-between gap-2">
+                        <h2 id="changelog-heading" className="text-base font-semibold text-gray-900 dark:text-gray-100">
+                            What's new in v{changelog.version}
+                        </h2>
+                        <p className="text-xs font-medium uppercase tracking-wide text-indigo-600 dark:text-indigo-400">
+                            {changelog.status}
+                            {changelog.released_at && (
+                                <>
+                                    {' · '}
+                                    <time dateTime={changelog.released_at}>{changelog.released_at}</time>
+                                </>
+                            )}
+                        </p>
+                    </div>
+
+                    <ul className="mt-3 space-y-3">
+                        {changelog.changes.map((change, index) => (
+                            <li key={`${change.category}-${index}`} className="text-sm text-gray-600 dark:text-gray-300">
+                                <span className="mr-2 font-medium text-gray-900 dark:text-gray-100">
+                                    {change.category}:
+                                </span>
+                                {change.description}
+                            </li>
+                        ))}
+                    </ul>
+                </section>
+            )}
         </GuestLayout>
     );
 }

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -1,12 +1,50 @@
 <?php
 
-use App\Modules\Auth\Middleware\RedirectIfAuthenticated;
 use App\Models\User;
+use App\Modules\Auth\Middleware\RedirectIfAuthenticated;
+use Inertia\Testing\AssertableInertia as Assert;
 
-test('login screen can be rendered', function () {
+test('login screen includes the latest public changelog entry', function () {
+    config()->set('changelog.releases', [
+        [
+            'version' => '2.0.6',
+            'status' => 'In development',
+            'released_at' => null,
+            'changes' => [
+                [
+                    'category' => 'Added',
+                    'description' => 'Added a public changes summary to the login page.',
+                ],
+            ],
+        ],
+        [
+            'version' => '2.0.5',
+            'status' => 'Released',
+            'released_at' => '2025-12-31',
+            'changes' => [],
+        ],
+    ]);
+
     $response = $this->get('/login');
 
-    $response->assertStatus(200);
+    $response->assertInertia(fn (Assert $page) => $page
+        ->component('Auth/Login')
+        ->where('changelog.version', '2.0.6')
+        ->where('changelog.status', 'In development')
+        ->where('changelog.released_at', null)
+        ->where('changelog.changes.0.category', 'Added')
+        ->where('changelog.changes.0.description', 'Added a public changes summary to the login page.')
+        ->missing('changelog.1'));
+});
+
+test('login screen handles an empty changelog', function () {
+    config()->set('changelog.releases', []);
+
+    $response = $this->get('/login');
+
+    $response->assertInertia(fn (Assert $page) => $page
+        ->component('Auth/Login')
+        ->where('changelog', null));
 });
 
 test('users can authenticate using the login screen', function () {


### PR DESCRIPTION
## Summary

- add a version-controlled, newest-first public changelog source
- expose only the latest entry to the login page as a page-specific Inertia prop
- render the entry as escaped semantic React text and hide the section when no entry exists
- cover populated and empty changelog states while retaining the existing authentication tests

## Security

- the login route receives curated public release text only
- no database, external API, global shared prop, Markdown, or raw HTML path is introduced
- final Codex Security diff scan completed with zero findings

## Validation

- `DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test tests/Feature/Auth/AuthenticationTest.php` — 4 passed, 35 assertions
- scoped Pint — passed
- `npx tsc --noEmit` — passed
- `npm run build` — passed
- `composer validate --strict` — passed
- `composer audit` — 0 advisories
- `npm audit` — 0 vulnerabilities
- `php artisan route:list` — 28 routes
- `git diff --check` — passed
- full isolated backend suite — 20 passed, 5 pre-existing failures (four missing auth Blade views and the existing profile soft-delete expectation)
- full-repository Pint retains unrelated pre-existing style failures; all changed PHP files pass scoped Pint

Closes #33
Refs #64
Refs #56
