### PR TITLE
Docs: Add repository-wide AI agent context (#62)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+# Copilot repository instructions
+
+Read and follow [`AGENTS.md`](../AGENTS.md). It is the canonical repository-wide instruction source; this file intentionally defines no separate project rules.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,85 @@
+# Expenses App agent instructions
+
+These instructions apply to the entire repository. This file is the canonical source for repository-wide AI-agent rules. Product-specific instruction files may point here, but must not copy mutable project facts.
+
+## Start with project truth
+
+Before changing the repository:
+
+1. Read [`README.md`](README.md) for the supported product and setup boundary.
+2. Read [`docs/README.md`](docs/README.md) to find the canonical document for the task.
+3. Inspect the relevant source, configuration, routes, tests, issue, and pull request before relying on prose.
+4. Resolve the active release train, integration branch, and PR base from verified GitHub state. Do not assume `main` is the correct base.
+
+Verified source and reproducible commands override stale prose. When they disagree, correct the canonical document or linked issue in the same change.
+
+## Product and architecture boundaries
+
+- Expenses App is a Laravel modular monolith with an Inertia, React, and TypeScript frontend.
+- Planning is the central stored monthly aggregate. Dashboard and Expenses are projections of Planning data.
+- Do not invent a transaction ledger, public REST API, new role model, or integration without an approved issue.
+- Keep business rules and authorization on the server. Client validation improves feedback but is never the only enforcement.
+- Preserve financial meaning, precision, ownership boundaries, and lifecycle invariants. Treat changes to calculations, persistence, deletion, and migrations as high risk.
+- Keep controllers focused on HTTP orchestration. Put reusable domain behavior in the owning module and follow existing module conventions.
+- Reuse existing routes, Inertia props, components, dictionaries, and services before adding parallel abstractions.
+
+## Documentation routing
+
+Use the documentation map in [`docs/README.md`](docs/README.md). In particular:
+
+- product entry point and local setup: [`README.md`](README.md);
+- release history: [`CHANGELOG.md`](CHANGELOG.md);
+- domain rules: `docs/domain/` when delivered by its linked issue;
+- architecture and codebase reference: `docs/codebase/` when delivered;
+- interface contracts: `docs/interfaces/` when delivered;
+- development and release workflow: `docs/development/` when delivered;
+- operations and monitoring: `docs/operations/` when delivered;
+- material architecture decisions: `docs/decisions/`.
+
+Describe unmerged behavior as planned and link its issue. Update documentation in the same PR when behavior, setup, interfaces, operations, or validation changes.
+
+## GitHub workflow and traceability
+
+- Use a detailed GitHub issue as the source of truth before broad implementation. Confirm its scope, acceptance criteria, risks, dependencies, release label, and branch plan.
+- Name branches with the issue number and intent. Keep commits focused and use Conventional Commit messages.
+- Link the implementation PR with `Closes #<issue>` and use `Refs #<issue>` for related work that the PR must not close.
+- Use stacked PRs only when changes are genuinely dependent. Each layer must be independently reviewable, have one clear issue, and target the branch immediately below it.
+- Review and merge a stack bottom-up. After a lower layer changes or merges, refresh the next layer and re-verify its base and diff.
+- Keep release aggregation separate from feature stacks. Do not merge, tag a release, delete a branch, or rewrite shared history without explicit authorization.
+
+## Implementation approach
+
+- Read nearby code and tests before editing; follow repository conventions instead of applying generic Laravel patterns blindly.
+- For a feature or bug fix, use a focused red-green-refactor cycle. Add or adjust the smallest test that proves the intended behavior before implementation.
+- Avoid unrelated refactors, formatting churn, dependency upgrades, generated files, or speculative abstractions.
+- Migrations must preserve existing data or document an explicit migration and rollback path. Never run destructive production or shared-database operations without explicit authorization.
+- Keep secrets, credentials, tokens, personal data, production identifiers, and raw diagnostics out of source, tests, issues, PRs, and documentation.
+- Monitoring and diagnostic tools must be disabled by default outside approved environments, require server-side authorization, minimize captured sensitive data, and define retention and rollback.
+
+## Validation
+
+Run the smallest relevant checks while developing, then run all configured checks affected by the change. The current baseline commands are:
+
+```bash
+composer validate --strict
+vendor/bin/pint --test
+php artisan test
+npx tsc --noEmit
+npm run build
+composer audit --locked --no-interaction
+npm audit --audit-level=high
+```
+
+Use an isolated test database. SQLite in memory is acceptable for compatible tests; use PostgreSQL when behavior depends on PostgreSQL semantics. Never point automated tests at development or production data.
+
+Also run configured static analysis, coverage, or security checks when they exist. If a repository-wide check already fails outside the change, report the exact baseline failure and verify that the focused change does not add another failure. Do not silently weaken or bypass a gate.
+
+## Hand-off standard
+
+Before opening or updating a PR:
+
+- inspect the final diff and confirm only intended files changed;
+- verify issue, branch, commit, base branch, labels, and closing references from GitHub;
+- report checks that passed, checks that failed, and whether failures predate the change;
+- call out migrations, configuration, security, financial, operational, and rollback impact;
+- leave merge, release tagging, and branch deletion to an explicitly authorized step.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude repository instructions
+
+Read and follow [`AGENTS.md`](AGENTS.md). It is the canonical repository-wide instruction source; this file intentionally defines no separate project rules.

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ This page maps each kind of project knowledge to one canonical source. Repositor
 | Development, validation, and release workflow | `docs/development/` | Planned in [#64](https://github.com/lurzar/expenses-app/issues/64) | Development owner; update when setup, quality gates, branching, versioning, or releases change. |
 | Error monitoring and operational response | `docs/operations/` | Planned in [#73](https://github.com/lurzar/expenses-app/issues/73) | Operations owner; update when monitoring, access, retention, incident response, or rollback changes. |
 | Architecture decisions | `docs/decisions/` | Reserved | Decision owner; add an ADR when an approved choice changes architecture, data, interfaces, or operations. |
-| Repository-wide AI-agent instructions | `AGENTS.md` | Planned in [#62](https://github.com/lurzar/expenses-app/issues/62) | Maintainers; update when repository rules, safety boundaries, or required checks change. |
+| Repository-wide AI-agent instructions | [`AGENTS.md`](../AGENTS.md) | Current | Maintainers; update when repository rules, safety boundaries, or required checks change. |
 
 Planned paths are declarations, not links to implemented documents. Follow the linked issue for the approved scope and delivery status.
 
@@ -61,4 +61,3 @@ The root README remains a concise entry point. Detailed project truth belongs in
 - Keep credentials, personal data, production identifiers, and raw diagnostic details out of documentation.
 - Check relative links from the file that contains them.
 - Update this map when adding, moving, or retiring a canonical document.
-


### PR DESCRIPTION
## Summary

Add one vendor-neutral, repository-wide source of AI-agent guidance on top of the documentation map introduced by #74.

## Stack

- GitHub stack: #76
- Layer 2 of 2; base: `docs/59-establish-documentation-source-of-truth`
- Lower required layer: #74
- Review and merge the stack bottom-up: #74, then this PR.

## Changes

- Add root `AGENTS.md` as the canonical repository instruction source.
- Define documentation routing, verified-base selection, dependent-only stacked PRs, Laravel/Inertia boundaries, validation, and hand-off requirements.
- Make authorization, diagnostic-data privacy, financial invariants, test-database isolation, and destructive-operation boundaries explicit.
- Add three-line Claude and Copilot discovery adapters that point to `AGENTS.md` without duplicating mutable rules.
- Mark the agent guidance current in `docs/README.md`.

## Validation

Passed:

- `git diff --check`
- instruction and adapter link-target checks
- clean-consumer check for the canonical documentation source, `v2.0.7` stack base, `v2.1` integration branch, required checks, and safety boundaries
- adapters are three lines each and contain no separate project rules
- cumulative stack: Composer validation, TypeScript, production build, Composer audit, and npm audit

Known repository baseline, tracked by #65:

- `php artisan test` with an isolated in-memory SQLite database: 20 passed, 5 failed. Existing failures cover missing auth views and the soft-delete account assertion.
- `vendor/bin/pint --test`: existing formatting findings across application and test files outside this documentation-only stack.

## Risk and rollback

Documentation and agent guidance only. No runtime behavior, dependency, configuration, database, or migration changes. Remove the thin adapters if a product stops requiring them; revert commit `c1bed1d` to roll back the complete layer.

Closes #62

Refs #59, #65, #67, #72, and #74
