### PR TITLE
Feat: Secure error monitoring and retention (#36)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,12 @@ WWWUSER=1000
 WWWGROUP=1000
 SAIL_XDEBUG_MODE=debug
 APP_PORT=8080
+
+# Telescope diagnostics (non-local access also requires an explicit allowlist)
 TELESCOPE_ENABLED=true
+TELESCOPE_AUTHORIZED_EMAILS=
+TELESCOPE_PRUNE_HOURS=168
+
 PGADMIN_PORT=8081
 PGADMIN_EMAIL=admin@admin.com
 PGADMIN_PASSWORD=password

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,12 +5,12 @@ namespace App\Providers;
 use App\Models\User;
 use App\Observers\UserObserver;
 use App\Providers\TelescopeServiceProvider as AppTelescopeServiceProvider;
-use Illuminate\Database\Eloquent\Factories\Factory;
-use Illuminate\Support\Str;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
 use Laravel\Telescope\TelescopeServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -20,7 +20,9 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        if ($this->app->environment('local') && class_exists(TelescopeServiceProvider::class)) {
+        $telescopeEnabled = $this->app->environment('local') || config('telescope.enabled') === true;
+
+        if ($telescopeEnabled && class_exists(TelescopeServiceProvider::class)) {
             $this->app->register(TelescopeServiceProvider::class);
             $this->app->register(AppTelescopeServiceProvider::class);
         }
@@ -52,12 +54,14 @@ class AppServiceProvider extends ServiceProvider
             if (str_contains($modelName, 'App\\Modules\\')) {
                 $moduleNamespace = Str::before($modelName, 'Models\\');
                 $modelBasename = class_basename($modelName);
-                return $moduleNamespace . 'Database\\Factories\\' . $modelBasename . 'Factory';
+
+                return $moduleNamespace.'Database\\Factories\\'.$modelBasename.'Factory';
             }
 
             $modelName = Str::afterLast($modelName, '\\');
-            return 'Database\\Factories\\' . $modelName . 'Factory';
-        });   
+
+            return 'Database\\Factories\\'.$modelName.'Factory';
+        });
     }
 
     /**
@@ -76,10 +80,11 @@ class AppServiceProvider extends ServiceProvider
 
             if (str_contains(get_class($factory), 'App\\Modules\\')) {
                 $moduleNamespace = Str::before(get_class($factory), 'Database\\Factories\\');
-                return $moduleNamespace . 'Models\\' . $factoryBasename;
+
+                return $moduleNamespace.'Models\\'.$factoryBasename;
             }
 
-            return 'App\\Models\\' . $factoryBasename;
+            return 'App\\Models\\'.$factoryBasename;
         });
     }
 }

--- a/app/Providers/TelescopeServiceProvider.php
+++ b/app/Providers/TelescopeServiceProvider.php
@@ -2,13 +2,38 @@
 
 namespace App\Providers;
 
+use App\Models\User;
 use Illuminate\Support\Facades\Gate;
 use Laravel\Telescope\IncomingEntry;
 use Laravel\Telescope\Telescope;
 use Laravel\Telescope\TelescopeApplicationServiceProvider;
+use Psr\Log\LogLevel;
 
 class TelescopeServiceProvider extends TelescopeApplicationServiceProvider
 {
+    /**
+     * Credential-bearing keys that must never be persisted by Telescope.
+     *
+     * @var list<string>
+     */
+    private const SENSITIVE_KEYS = [
+        '_token',
+        'password',
+        'password_confirmation',
+        'current_password',
+        'new_password',
+        'new_password_confirmation',
+        'token',
+        'access_token',
+        'api_token',
+        'authorization',
+        'cookie',
+        'x_csrf_token',
+        'x_xsrf_token',
+        'x_api_key',
+        'php_auth_pw',
+    ];
+
     /**
      * Register any application services.
      */
@@ -18,16 +43,23 @@ class TelescopeServiceProvider extends TelescopeApplicationServiceProvider
 
         $this->hideSensitiveRequestDetails();
 
-        Telescope::filter(function (IncomingEntry $entry) {
+        Telescope::filter(function (IncomingEntry $entry): bool {
             if ($this->app->environment('local')) {
                 return true;
             }
 
-            return $entry->isReportableException() ||
-                   $entry->isFailedRequest() ||
-                   $entry->isFailedJob() ||
-                   $entry->isScheduledTask() ||
-                   $entry->hasMonitoredTag();
+            $retained = $entry->isReportableException() ||
+                        $entry->isFailedRequest() ||
+                        $entry->isFailedJob() ||
+                        $entry->isScheduledTask() ||
+                        $this->isErrorLog($entry) ||
+                        $entry->hasMonitoredTag();
+
+            if ($retained) {
+                $this->redactSensitiveEntry($entry);
+            }
+
+            return $retained;
         });
     }
 
@@ -40,12 +72,24 @@ class TelescopeServiceProvider extends TelescopeApplicationServiceProvider
             return;
         }
 
-        Telescope::hideRequestParameters(['_token']);
+        Telescope::hideRequestParameters([
+            '_token',
+            'password',
+            'password_confirmation',
+            'current_password',
+            'new_password',
+            'new_password_confirmation',
+            'token',
+            'access_token',
+            'api_token',
+        ]);
 
         Telescope::hideRequestHeaders([
+            'authorization',
             'cookie',
             'x-csrf-token',
             'x-xsrf-token',
+            'x-api-key',
         ]);
     }
 
@@ -56,10 +100,100 @@ class TelescopeServiceProvider extends TelescopeApplicationServiceProvider
      */
     protected function gate(): void
     {
-        Gate::define('viewTelescope', function ($user) {
-            return in_array($user->email, [
-                //
-            ]);
+        Gate::define('viewTelescope', function (?User $user = null): bool {
+            if ($user === null || $user->email_verified_at === null) {
+                return false;
+            }
+
+            $email = strtolower(trim((string) $user->email));
+
+            return in_array($email, $this->authorizedEmails(), true);
         });
+    }
+
+    /**
+     * Get the configured non-local operator emails or fail closed.
+     *
+     * @return list<string>
+     */
+    private function authorizedEmails(): array
+    {
+        $configured = config('telescope.authorized_emails');
+
+        if (! is_string($configured)) {
+            return [];
+        }
+
+        $emails = array_values(array_filter(
+            array_map('trim', explode(',', $configured)),
+            fn (string $email): bool => $email !== '',
+        ));
+
+        if ($emails === []) {
+            return [];
+        }
+
+        foreach ($emails as $email) {
+            if (filter_var($email, FILTER_VALIDATE_EMAIL) === false) {
+                return [];
+            }
+        }
+
+        return array_values(array_unique(array_map('strtolower', $emails)));
+    }
+
+    private function isErrorLog(IncomingEntry $entry): bool
+    {
+        if (! $entry->isLog()) {
+            return false;
+        }
+
+        return in_array(strtolower((string) ($entry->content['level'] ?? '')), [
+            LogLevel::ERROR,
+            LogLevel::CRITICAL,
+            LogLevel::ALERT,
+            LogLevel::EMERGENCY,
+        ], true);
+    }
+
+    /**
+     * Recursively remove credentials that top-level Telescope redaction misses.
+     */
+    private function redactSensitiveEntry(IncomingEntry $entry): void
+    {
+        if (! $entry->isRequest() && ! $entry->isLog()) {
+            return;
+        }
+
+        $redacted = false;
+        $entry->content = $this->redactSensitiveValues($entry->content, $redacted);
+
+        if ($entry->isLog() && $redacted) {
+            $entry->content['message'] = '[Redacted sensitive error log]';
+        }
+    }
+
+    /**
+     * @param  array<mixed>  $values
+     * @return array<mixed>
+     */
+    private function redactSensitiveValues(array $values, bool &$redacted): array
+    {
+        foreach ($values as $key => $value) {
+            $normalizedKey = str_replace('-', '_', strtolower((string) $key));
+
+            if (in_array($normalizedKey, self::SENSITIVE_KEYS, true)) {
+                $values[$key] = '********';
+                $redacted = true;
+
+                continue;
+            }
+
+            if (is_array($value)) {
+                $values[$key] = $this->redactSensitiveValues($value, $redacted);
+            }
+        }
+
+        return $values;
     }
 }

--- a/config/telescope.php
+++ b/config/telescope.php
@@ -62,7 +62,19 @@ return [
     |
     */
 
-    'enabled' => env('TELESCOPE_ENABLED', false),
+    'enabled' => filter_var(
+        env('TELESCOPE_ENABLED', false),
+        FILTER_VALIDATE_BOOLEAN,
+        FILTER_NULL_ON_FAILURE,
+    ) ?? false,
+
+    'authorized_emails' => env('TELESCOPE_AUTHORIZED_EMAILS', ''),
+
+    'prune_hours' => filter_var(
+        env('TELESCOPE_PRUNE_HOURS', 168),
+        FILTER_VALIDATE_INT,
+        ['options' => ['min_range' => 1]],
+    ) ?: 168,
 
     /*
     |--------------------------------------------------------------------------

--- a/routes/console.php
+++ b/routes/console.php
@@ -13,4 +13,14 @@ use Illuminate\Support\Facades\Schedule;
 |
 */
 
-Schedule::command('telescope:prune --hours=1')->everyThreeMinutes();
+if (app()->environment('local') || config('telescope.enabled') === true) {
+    $retentionHours = filter_var(
+        config('telescope.prune_hours', 168),
+        FILTER_VALIDATE_INT,
+        ['options' => ['min_range' => 1]],
+    ) ?: 168;
+
+    Schedule::command("telescope:prune --hours={$retentionHours}")
+        ->daily()
+        ->withoutOverlapping();
+}

--- a/tests/Feature/System/TelescopeSecurityTest.php
+++ b/tests/Feature/System/TelescopeSecurityTest.php
@@ -1,0 +1,269 @@
+<?php
+
+use App\Models\User;
+use App\Providers\AppServiceProvider;
+use App\Providers\TelescopeServiceProvider as AppTelescopeServiceProvider;
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Str;
+use Laravel\Telescope\EntryType;
+use Laravel\Telescope\IncomingEntry;
+use Laravel\Telescope\Telescope;
+use Laravel\Telescope\TelescopeServiceProvider;
+
+beforeEach(function () {
+    Telescope::$filterUsing = [];
+    Telescope::$hiddenRequestHeaders = ['authorization', 'php-auth-pw'];
+    Telescope::$hiddenRequestParameters = ['password', 'password_confirmation'];
+});
+
+function useNonLocalEnvironment(): void
+{
+    app()->detectEnvironment(fn () => 'production');
+}
+
+function registerApplicationTelescopeProvider(): void
+{
+    $provider = new AppTelescopeServiceProvider(app());
+    $provider->register();
+    $provider->boot();
+}
+
+test('non-local telescope registration follows loaded configuration', function () {
+    useNonLocalEnvironment();
+    config()->set('telescope.enabled', true);
+
+    (new AppServiceProvider(app()))->register();
+
+    expect(app()->getProvider(TelescopeServiceProvider::class))->not->toBeNull()
+        ->and(app()->getProvider(AppTelescopeServiceProvider::class))->not->toBeNull();
+});
+
+test('non-local telescope remains unregistered when loaded configuration disables it', function () {
+    useNonLocalEnvironment();
+    config()->set('telescope.enabled', false);
+
+    (new AppServiceProvider(app()))->register();
+
+    expect(app()->getProvider(TelescopeServiceProvider::class))->toBeNull()
+        ->and(app()->getProvider(AppTelescopeServiceProvider::class))->toBeNull();
+});
+
+test('non-local telescope fails closed when loaded enablement is malformed', function () {
+    useNonLocalEnvironment();
+    config()->set('telescope.enabled', 'typo');
+
+    (new AppServiceProvider(app()))->register();
+
+    expect(app()->getProvider(TelescopeServiceProvider::class))->toBeNull()
+        ->and(app()->getProvider(AppTelescopeServiceProvider::class))->toBeNull();
+});
+
+test('local telescope remains available when its loaded configuration is disabled', function () {
+    app()->detectEnvironment(fn () => 'local');
+    config()->set('telescope.enabled', false);
+
+    (new AppServiceProvider(app()))->register();
+
+    expect(app()->getProvider(TelescopeServiceProvider::class))->not->toBeNull()
+        ->and(app()->getProvider(AppTelescopeServiceProvider::class))->not->toBeNull();
+});
+
+test('non-local telescope routes deny guests when enabled', function () {
+    useNonLocalEnvironment();
+    config()->set([
+        'telescope.enabled' => true,
+        'telescope.authorized_emails' => 'operator@example.com',
+    ]);
+
+    (new AppServiceProvider(app()))->register();
+
+    $this->get('/telescope')->assertForbidden();
+});
+
+test('a verified allowlisted operator can view non-local telescope', function () {
+    useNonLocalEnvironment();
+    config()->set('telescope.authorized_emails', ' first@example.com, OPERATOR@example.com ');
+    registerApplicationTelescopeProvider();
+    $operator = User::factory()->create(['email' => 'operator@example.com']);
+
+    expect(Gate::forUser($operator)->allows('viewTelescope'))->toBeTrue();
+});
+
+test('non-local telescope rejects unverified unlisted and malformed authorization', function () {
+    useNonLocalEnvironment();
+    $verified = User::factory()->create(['email' => 'operator@example.com']);
+    $unverified = User::factory()->unverified()->create(['email' => 'unverified@example.com']);
+
+    config()->set('telescope.authorized_emails', 'other@example.com');
+    registerApplicationTelescopeProvider();
+    expect(Gate::forUser($verified)->allows('viewTelescope'))->toBeFalse();
+
+    config()->set('telescope.authorized_emails', 'operator@example.com,not-an-email');
+    registerApplicationTelescopeProvider();
+    expect(Gate::forUser($verified)->allows('viewTelescope'))->toBeFalse();
+
+    config()->set('telescope.authorized_emails', 'unverified@example.com');
+    registerApplicationTelescopeProvider();
+    expect(Gate::forUser($unverified)->allows('viewTelescope'))->toBeFalse();
+});
+
+test('non-local request diagnostics redact approved credentials and headers', function () {
+    useNonLocalEnvironment();
+    registerApplicationTelescopeProvider();
+
+    expect(Telescope::$hiddenRequestParameters)->toContain(
+        '_token',
+        'password',
+        'password_confirmation',
+        'current_password',
+        'token',
+        'access_token',
+        'api_token',
+    )->and(Telescope::$hiddenRequestHeaders)->toContain(
+        'authorization',
+        'cookie',
+        'x-csrf-token',
+        'x-xsrf-token',
+        'x-api-key',
+    );
+});
+
+test('non-local retained requests recursively redact nested credentials', function () {
+    useNonLocalEnvironment();
+    registerApplicationTelescopeProvider();
+    $filter = Telescope::$filterUsing[array_key_last(Telescope::$filterUsing)];
+    $request = IncomingEntry::make([
+        'response_status' => 500,
+        'payload' => [
+            'credentials' => [
+                'password' => 'nested-password',
+                'token' => 'nested-token',
+            ],
+            'safe' => 'diagnostic-value',
+        ],
+        'session' => [
+            'nested' => ['access-token' => 'session-token'],
+        ],
+        'headers' => [
+            'x-api-key' => 'request-api-key',
+        ],
+    ])->type(EntryType::REQUEST);
+
+    expect($filter($request))->toBeTrue()
+        ->and($request->content['payload']['credentials']['password'])->toBe('********')
+        ->and($request->content['payload']['credentials']['token'])->toBe('********')
+        ->and($request->content['session']['nested']['access-token'])->toBe('********')
+        ->and($request->content['headers']['x-api-key'])->toBe('********')
+        ->and($request->content['payload']['safe'])->toBe('diagnostic-value');
+});
+
+test('non-local retained error logs redact nested context and interpolated messages', function () {
+    useNonLocalEnvironment();
+    registerApplicationTelescopeProvider();
+    $filter = Telescope::$filterUsing[array_key_last(Telescope::$filterUsing)];
+    $log = IncomingEntry::make([
+        'level' => 'error',
+        'message' => 'Authentication failed with token raw-log-token',
+        'context' => [
+            'credentials' => ['token' => 'raw-log-token'],
+            'safe' => 'diagnostic-value',
+        ],
+    ])->type(EntryType::LOG);
+
+    expect($filter($log))->toBeTrue()
+        ->and($log->content['context']['credentials']['token'])->toBe('********')
+        ->and($log->content['message'])->not->toContain('raw-log-token')
+        ->and($log->content['context']['safe'])->toBe('diagnostic-value');
+});
+
+test('non-local filtering retains failures and error logs without routine noise', function () {
+    useNonLocalEnvironment();
+    registerApplicationTelescopeProvider();
+    $filter = Telescope::$filterUsing[array_key_last(Telescope::$filterUsing)];
+
+    $failedRequest = IncomingEntry::make(['response_status' => 500])->type(EntryType::REQUEST);
+    $failedJob = IncomingEntry::make(['status' => 'failed'])->type(EntryType::JOB);
+    $errorLog = IncomingEntry::make(['level' => 'error'])->type(EntryType::LOG);
+    $debugLog = IncomingEntry::make(['level' => 'debug'])->type(EntryType::LOG);
+    $successfulRequest = IncomingEntry::make(['response_status' => 200])->type(EntryType::REQUEST);
+
+    expect($filter($failedRequest))->toBeTrue()
+        ->and($filter($failedJob))->toBeTrue()
+        ->and($filter($errorLog))->toBeTrue()
+        ->and($filter($debugLog))->toBeFalse()
+        ->and($filter($successfulRequest))->toBeFalse();
+});
+
+test('disabled telescope has no pruning schedule', function () {
+    $pruneEvents = collect(app(Schedule::class)->events())
+        ->filter(fn ($event) => Str::contains($event->command ?? '', 'telescope:prune'));
+
+    expect($pruneEvents)->toBeEmpty();
+});
+
+test('enabled telescope uses configured daily pruning', function () {
+    config()->set([
+        'telescope.enabled' => true,
+        'telescope.prune_hours' => 168,
+    ]);
+
+    require base_path('routes/console.php');
+
+    $event = collect(app(Schedule::class)->events())
+        ->first(fn ($event) => Str::contains($event->command ?? '', 'telescope:prune --hours=168'));
+
+    expect($event)->not->toBeNull()
+        ->and($event->expression)->toBe('0 0 * * *');
+});
+
+test('malformed pruning retention fails closed to the documented default', function () {
+    config()->set([
+        'telescope.enabled' => true,
+        'telescope.prune_hours' => 'invalid',
+    ]);
+
+    require base_path('routes/console.php');
+
+    $event = collect(app(Schedule::class)->events())
+        ->first(fn ($event) => Str::contains($event->command ?? '', 'telescope:prune --hours=168'));
+
+    expect($event)->not->toBeNull();
+});
+
+test('configured pruning deletes expired entries and retains recent entries', function () {
+    useNonLocalEnvironment();
+    config()->set('telescope.enabled', true);
+    (new AppServiceProvider(app()))->register();
+
+    DB::table('telescope_entries')->insert([
+        [
+            'uuid' => (string) Str::uuid(),
+            'batch_id' => (string) Str::uuid(),
+            'type' => EntryType::LOG,
+            'content' => '{}',
+            'created_at' => now()->subHours(169),
+        ],
+        [
+            'uuid' => (string) Str::uuid(),
+            'batch_id' => (string) Str::uuid(),
+            'type' => EntryType::LOG,
+            'content' => '{}',
+            'created_at' => now()->subHours(167),
+        ],
+    ]);
+
+    $this->artisan('telescope:prune', ['--hours' => 168])->assertSuccessful();
+
+    expect(DB::table('telescope_entries')->count())->toBe(1);
+});
+
+test('example environment documents safe telescope controls', function () {
+    $environment = file_get_contents(base_path('.env.example'));
+
+    expect($environment)->toContain(
+        'TELESCOPE_AUTHORIZED_EMAILS=',
+        'TELESCOPE_PRUNE_HOURS=168',
+    );
+});


### PR DESCRIPTION
## Summary

Secure and operationalize the existing Laravel Telescope path for non-local diagnostics while preserving local development behavior.

Closes #36
Refs #13, #67, #72, and #73

## Changes

- require explicit boolean Telescope enablement outside `local`;
- require a verified user from a fail-closed environment email allowlist;
- retain reportable failures, scheduled tasks, monitored entries, and error-level logs outside `local`;
- redact known credential parameters and headers, including nested request and log fields;
- replace an interpolated log message when its context required credential redaction;
- schedule daily retention pruning with a validated 168-hour default; and
- add focused provider, authorization, filtering, redaction, scheduling, and pruning tests.

## Security review

The diff security scan found one low-severity nested credential-redaction bypass. Regression tests reproduced it before remediation. Recursive sanitization now closes that path while preserving safe diagnostic context. Malformed enablement and retention values also fail closed.

## Validation

- focused Telescope suite: 16 passed, 48 assertions;
- changed-file Pint and `git diff --check`: passed;
- route, schedule, configuration-cache, and isolated prune checks: passed;
- Composer validation/audit: passed, no advisories;
- npm audit: passed, zero vulnerabilities;
- TypeScript check and production build: passed;
- full SQLite suite: 36 passed, 5 pre-existing failures tracked by #65.

## Stack

- Base: `v2.0.7`
- This PR: implementation for #36
- Next: #78, operator documentation for #73

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>
