### PR TITLE
Development of Version 2.0.7

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,12 @@ WWWUSER=1000
 WWWGROUP=1000
 SAIL_XDEBUG_MODE=debug
 APP_PORT=8080
+
+# Telescope diagnostics (non-local access also requires an explicit allowlist)
 TELESCOPE_ENABLED=true
+TELESCOPE_AUTHORIZED_EMAILS=
+TELESCOPE_PRUNE_HOURS=168
+
 PGADMIN_PORT=8081
 PGADMIN_EMAIL=admin@admin.com
 PGADMIN_PASSWORD=password

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+# Copilot repository instructions
+
+Read and follow [`AGENTS.md`](../AGENTS.md). It is the canonical repository-wide instruction source; this file intentionally defines no separate project rules.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,85 @@
+# Expenses App agent instructions
+
+These instructions apply to the entire repository. This file is the canonical source for repository-wide AI-agent rules. Product-specific instruction files may point here, but must not copy mutable project facts.
+
+## Start with project truth
+
+Before changing the repository:
+
+1. Read [`README.md`](README.md) for the supported product and setup boundary.
+2. Read [`docs/README.md`](docs/README.md) to find the canonical document for the task.
+3. Inspect the relevant source, configuration, routes, tests, issue, and pull request before relying on prose.
+4. Resolve the active release train, integration branch, and PR base from verified GitHub state. Do not assume `main` is the correct base.
+
+Verified source and reproducible commands override stale prose. When they disagree, correct the canonical document or linked issue in the same change.
+
+## Product and architecture boundaries
+
+- Expenses App is a Laravel modular monolith with an Inertia, React, and TypeScript frontend.
+- Planning is the central stored monthly aggregate. Dashboard and Expenses are projections of Planning data.
+- Do not invent a transaction ledger, public REST API, new role model, or integration without an approved issue.
+- Keep business rules and authorization on the server. Client validation improves feedback but is never the only enforcement.
+- Preserve financial meaning, precision, ownership boundaries, and lifecycle invariants. Treat changes to calculations, persistence, deletion, and migrations as high risk.
+- Keep controllers focused on HTTP orchestration. Put reusable domain behavior in the owning module and follow existing module conventions.
+- Reuse existing routes, Inertia props, components, dictionaries, and services before adding parallel abstractions.
+
+## Documentation routing
+
+Use the documentation map in [`docs/README.md`](docs/README.md). In particular:
+
+- product entry point and local setup: [`README.md`](README.md);
+- release history: [`CHANGELOG.md`](CHANGELOG.md);
+- domain rules: `docs/domain/` when delivered by its linked issue;
+- architecture and codebase reference: `docs/codebase/` when delivered;
+- interface contracts: `docs/interfaces/` when delivered;
+- development and release workflow: `docs/development/` when delivered;
+- operations and monitoring: `docs/operations/` when delivered;
+- material architecture decisions: `docs/decisions/`.
+
+Describe unmerged behavior as planned and link its issue. Update documentation in the same PR when behavior, setup, interfaces, operations, or validation changes.
+
+## GitHub workflow and traceability
+
+- Use a detailed GitHub issue as the source of truth before broad implementation. Confirm its scope, acceptance criteria, risks, dependencies, release label, and branch plan.
+- Name branches with the issue number and intent. Keep commits focused and use Conventional Commit messages.
+- Link the implementation PR with `Closes #<issue>` and use `Refs #<issue>` for related work that the PR must not close.
+- Use stacked PRs only when changes are genuinely dependent. Each layer must be independently reviewable, have one clear issue, and target the branch immediately below it.
+- Review and merge a stack bottom-up. After a lower layer changes or merges, refresh the next layer and re-verify its base and diff.
+- Keep release aggregation separate from feature stacks. Do not merge, tag a release, delete a branch, or rewrite shared history without explicit authorization.
+
+## Implementation approach
+
+- Read nearby code and tests before editing; follow repository conventions instead of applying generic Laravel patterns blindly.
+- For a feature or bug fix, use a focused red-green-refactor cycle. Add or adjust the smallest test that proves the intended behavior before implementation.
+- Avoid unrelated refactors, formatting churn, dependency upgrades, generated files, or speculative abstractions.
+- Migrations must preserve existing data or document an explicit migration and rollback path. Never run destructive production or shared-database operations without explicit authorization.
+- Keep secrets, credentials, tokens, personal data, production identifiers, and raw diagnostics out of source, tests, issues, PRs, and documentation.
+- Monitoring and diagnostic tools must be disabled by default outside approved environments, require server-side authorization, minimize captured sensitive data, and define retention and rollback.
+
+## Validation
+
+Run the smallest relevant checks while developing, then run all configured checks affected by the change. The current baseline commands are:
+
+```bash
+composer validate --strict
+vendor/bin/pint --test
+php artisan test
+npx tsc --noEmit
+npm run build
+composer audit --locked --no-interaction
+npm audit --audit-level=high
+```
+
+Use an isolated test database. SQLite in memory is acceptable for compatible tests; use PostgreSQL when behavior depends on PostgreSQL semantics. Never point automated tests at development or production data.
+
+Also run configured static analysis, coverage, or security checks when they exist. If a repository-wide check already fails outside the change, report the exact baseline failure and verify that the focused change does not add another failure. Do not silently weaken or bypass a gate.
+
+## Hand-off standard
+
+Before opening or updating a PR:
+
+- inspect the final diff and confirm only intended files changed;
+- verify issue, branch, commit, base branch, labels, and closing references from GitHub;
+- report checks that passed, checks that failed, and whether failures predate the change;
+- call out migrations, configuration, security, financial, operational, and rollback impact;
+- leave merge, release tagging, and branch deletion to an explicitly authorized step.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+## [2.0.7] - 2026-08-15
+
+### Added
+
+- Added a canonical documentation map, repository-wide contributor guidance, and an operator runbook for error diagnostics and incident response.
+
+### Changed
+
+- Replaced the development Telescope pruning loop with configurable daily retention.
+- Limited non-local diagnostics to reportable failures, scheduled tasks, monitored entries, and error-level logs.
+
+### Security
+
+- Added explicit non-local Telescope enablement, verified-operator authorization, fail-closed configuration, and recursive credential redaction.
+
 ## [2.0.6] - 2026-08-15
 
 ### Added
@@ -22,5 +37,6 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 - Updated Composer and npm dependencies to remove known security advisories while remaining on the intended major versions.
 
-[Unreleased]: https://github.com/lurzar/expenses-app/compare/v2.0.6-dev...HEAD
+[Unreleased]: https://github.com/lurzar/expenses-app/compare/v2.0.7-dev...HEAD
+[2.0.7]: https://github.com/lurzar/expenses-app/compare/v2.0.6-dev...v2.0.7-dev
 [2.0.6]: https://github.com/lurzar/expenses-app/compare/v2.0.5-dev...v2.0.6-dev

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude repository instructions
+
+Read and follow [`AGENTS.md`](AGENTS.md). It is the canonical repository-wide instruction source; this file intentionally defines no separate project rules.

--- a/README.md
+++ b/README.md
@@ -1,66 +1,83 @@
-<p align="center"><a href="https://laravel.com" target="_blank"><img src="https://raw.githubusercontent.com/laravel/art/master/logo-lockup/5%20SVG/2%20CMYK/1%20Full%20Color/laravel-logolockup-cmyk-red.svg" width="400" alt="Laravel Logo"></a></p>
+<div align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="./public/images/logo-white.png">
+    <source media="(prefers-color-scheme: light)" srcset="./public/images/logo-black.png">
+    <img src="./public/images/logo-black.png" alt="Expenses App" width="420">
+  </picture>
 
-<p align="center">
-<a href="https://github.com/laravel/framework/actions"><img src="https://github.com/laravel/framework/workflows/tests/badge.svg" alt="Build Status"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/dt/laravel/framework" alt="Total Downloads"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/v/laravel/framework" alt="Latest Stable Version"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/l/laravel/framework" alt="License"></a>
-</p>
+  <p>Plan a month, understand the allocation, and replace a manual expense-planning spreadsheet with one web application.</p>
+</div>
 
-## About Laravel
+## Overview
 
-Laravel is a web application framework with expressive, elegant syntax. We believe development must be an enjoyable and creative experience to be truly fulfilling. Laravel takes the pain out of development by easing common tasks used in many web projects, such as:
+Expenses App is a personal monthly-planning application. A user records income and planned savings, commitments, and other spending for a month. The application stores that plan and presents it through Planning, Dashboard, and Expenses views.
 
-- [Simple, fast routing engine](https://laravel.com/docs/routing).
-- [Powerful dependency injection container](https://laravel.com/docs/container).
-- Multiple back-ends for [session](https://laravel.com/docs/session) and [cache](https://laravel.com/docs/cache) storage.
-- Expressive, intuitive [database ORM](https://laravel.com/docs/eloquent).
-- Database agnostic [schema migrations](https://laravel.com/docs/migrations).
-- [Robust background job processing](https://laravel.com/docs/queues).
-- [Real-time event broadcasting](https://laravel.com/docs/broadcasting).
+The current Expenses view is a projection of monthly Planning data. It is not a transaction ledger, and the application does not expose a public REST API.
 
-Laravel is accessible, powerful, and provides tools required for large, robust applications.
+## Current capabilities
 
-## Learning Laravel
+- Register, sign in, sign out, and manage a profile.
+- Create, review, list, and delete monthly plans.
+- Organize planned amounts into savings, commitments, and other spending.
+- Review planning summaries through Dashboard and Expenses views.
+- Switch between English and Malay interface dictionaries.
+- Run locally with Laravel Sail, PostgreSQL, Redis, and pgAdmin.
 
-Laravel has the most extensive and thorough [documentation](https://laravel.com/docs) and video tutorial library of all modern web application frameworks, making it a breeze to get started with the framework.
+## Architecture
 
-You may also try the [Laravel Bootcamp](https://bootcamp.laravel.com), where you will be guided through building a modern Laravel application from scratch.
+Expenses App is a Laravel 12 modular monolith. Laravel modules own the web routes and server-side orchestration; Inertia 2 connects them to a React 19 and TypeScript frontend.
 
-If you don't feel like reading, [Laracasts](https://laracasts.com) can help. Laracasts contains over 2000 video tutorials on a range of topics including Laravel, modern PHP, unit testing, and JavaScript. Boost your skills by digging into our comprehensive video library.
+Planning is the central stored aggregate. Dashboard and Expenses read Planning data through the Planning service. PostgreSQL stores application data, while Redis is available to the local stack for future cache and queue use.
 
-## Laravel Sponsors
+See the [documentation map](docs/README.md) for current references and issue-backed planned documentation.
 
-We would like to extend our thanks to the following sponsors for funding Laravel development. If you are interested in becoming a sponsor, please visit the Laravel [Patreon page](https://patreon.com/taylorotwell).
+## Getting started
 
-### Premium Partners
+### Prerequisites
 
-- **[Vehikl](https://vehikl.com/)**
-- **[Tighten Co.](https://tighten.co)**
-- **[Kirschbaum Development Group](https://kirschbaumdevelopment.com)**
-- **[64 Robots](https://64robots.com)**
-- **[Cubet Techno Labs](https://cubettech.com)**
-- **[Cyber-Duck](https://cyber-duck.co.uk)**
-- **[Many](https://www.many.co.uk)**
-- **[Webdock, Fast VPS Hosting](https://www.webdock.io/en)**
-- **[DevSquad](https://devsquad.com)**
-- **[Curotec](https://www.curotec.com/services/technologies/laravel/)**
-- **[OP.GG](https://op.gg)**
-- **[WebReinvent](https://webreinvent.com/?utm_source=laravel&utm_medium=github&utm_campaign=patreon-sponsors)**
-- **[Lendio](https://lendio.com)**
+- PHP 8.4
+- Composer 2
+- Docker with Docker Compose
+- Node.js 22 and npm
 
-## Contributing
+> [!IMPORTANT]
+> The development stack uses PostgreSQL 18. If you already have an Expenses App database volume created by PostgreSQL 17 or earlier, follow the [PostgreSQL 18 upgrade guide](docs/postgresql-18-upgrade.md) before starting the updated stack.
 
-Thank you for considering contributing to the Laravel framework! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).
+### Set up the application
 
-## Code of Conduct
+```bash
+git clone https://github.com/lurzar/expenses-app.git
+cd expenses-app
+composer install
+cp .env.example .env
+php artisan key:generate
+npm ci
+./vendor/bin/sail up -d
+./vendor/bin/sail artisan migrate
+npm run dev
+```
 
-In order to ensure that the Laravel community is welcoming to all, please review and abide by the [Code of Conduct](https://laravel.com/docs/contributions#code-of-conduct).
+Open [http://localhost:8080](http://localhost:8080). The port comes from `APP_PORT` in `.env.example`.
 
-## Security Vulnerabilities
+### Run the available checks
 
-If you discover a security vulnerability within Laravel, please send an e-mail to Taylor Otwell via [taylor@laravel.com](mailto:taylor@laravel.com). All security vulnerabilities will be promptly addressed.
+```bash
+composer validate --strict
+DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test
+vendor/bin/pint --test
+npx tsc --noEmit
+npm run build
+composer audit --locked
+npm audit --package-lock-only
+```
 
-## License
+The repository is still establishing a deterministic quality baseline in [issue #65](https://github.com/lurzar/expenses-app/issues/65). Treat a local environment failure as a failure to investigate, not as a passing check.
 
-The Laravel framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).
+## Documentation
+
+- [Documentation map and ownership](docs/README.md)
+- [PostgreSQL 18 local-volume upgrade](docs/postgresql-18-upgrade.md)
+- [Release history](CHANGELOG.md)
+- [Version 2.0.7 plan](https://github.com/lurzar/expenses-app/issues/72)
+
+GitHub Issues hold planned work. Repository documentation describes approved, current behavior. When the two disagree, verify the source and update the stale issue or document.

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,12 +5,12 @@ namespace App\Providers;
 use App\Models\User;
 use App\Observers\UserObserver;
 use App\Providers\TelescopeServiceProvider as AppTelescopeServiceProvider;
-use Illuminate\Database\Eloquent\Factories\Factory;
-use Illuminate\Support\Str;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
 use Laravel\Telescope\TelescopeServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -20,7 +20,9 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        if ($this->app->environment('local') && class_exists(TelescopeServiceProvider::class)) {
+        $telescopeEnabled = $this->app->environment('local') || config('telescope.enabled') === true;
+
+        if ($telescopeEnabled && class_exists(TelescopeServiceProvider::class)) {
             $this->app->register(TelescopeServiceProvider::class);
             $this->app->register(AppTelescopeServiceProvider::class);
         }
@@ -52,12 +54,14 @@ class AppServiceProvider extends ServiceProvider
             if (str_contains($modelName, 'App\\Modules\\')) {
                 $moduleNamespace = Str::before($modelName, 'Models\\');
                 $modelBasename = class_basename($modelName);
-                return $moduleNamespace . 'Database\\Factories\\' . $modelBasename . 'Factory';
+
+                return $moduleNamespace.'Database\\Factories\\'.$modelBasename.'Factory';
             }
 
             $modelName = Str::afterLast($modelName, '\\');
-            return 'Database\\Factories\\' . $modelName . 'Factory';
-        });   
+
+            return 'Database\\Factories\\'.$modelName.'Factory';
+        });
     }
 
     /**
@@ -76,10 +80,11 @@ class AppServiceProvider extends ServiceProvider
 
             if (str_contains(get_class($factory), 'App\\Modules\\')) {
                 $moduleNamespace = Str::before(get_class($factory), 'Database\\Factories\\');
-                return $moduleNamespace . 'Models\\' . $factoryBasename;
+
+                return $moduleNamespace.'Models\\'.$factoryBasename;
             }
 
-            return 'App\\Models\\' . $factoryBasename;
+            return 'App\\Models\\'.$factoryBasename;
         });
     }
 }

--- a/app/Providers/TelescopeServiceProvider.php
+++ b/app/Providers/TelescopeServiceProvider.php
@@ -2,13 +2,38 @@
 
 namespace App\Providers;
 
+use App\Models\User;
 use Illuminate\Support\Facades\Gate;
 use Laravel\Telescope\IncomingEntry;
 use Laravel\Telescope\Telescope;
 use Laravel\Telescope\TelescopeApplicationServiceProvider;
+use Psr\Log\LogLevel;
 
 class TelescopeServiceProvider extends TelescopeApplicationServiceProvider
 {
+    /**
+     * Credential-bearing keys that must never be persisted by Telescope.
+     *
+     * @var list<string>
+     */
+    private const SENSITIVE_KEYS = [
+        '_token',
+        'password',
+        'password_confirmation',
+        'current_password',
+        'new_password',
+        'new_password_confirmation',
+        'token',
+        'access_token',
+        'api_token',
+        'authorization',
+        'cookie',
+        'x_csrf_token',
+        'x_xsrf_token',
+        'x_api_key',
+        'php_auth_pw',
+    ];
+
     /**
      * Register any application services.
      */
@@ -18,16 +43,23 @@ class TelescopeServiceProvider extends TelescopeApplicationServiceProvider
 
         $this->hideSensitiveRequestDetails();
 
-        Telescope::filter(function (IncomingEntry $entry) {
+        Telescope::filter(function (IncomingEntry $entry): bool {
             if ($this->app->environment('local')) {
                 return true;
             }
 
-            return $entry->isReportableException() ||
-                   $entry->isFailedRequest() ||
-                   $entry->isFailedJob() ||
-                   $entry->isScheduledTask() ||
-                   $entry->hasMonitoredTag();
+            $retained = $entry->isReportableException() ||
+                        $entry->isFailedRequest() ||
+                        $entry->isFailedJob() ||
+                        $entry->isScheduledTask() ||
+                        $this->isErrorLog($entry) ||
+                        $entry->hasMonitoredTag();
+
+            if ($retained) {
+                $this->redactSensitiveEntry($entry);
+            }
+
+            return $retained;
         });
     }
 
@@ -40,12 +72,24 @@ class TelescopeServiceProvider extends TelescopeApplicationServiceProvider
             return;
         }
 
-        Telescope::hideRequestParameters(['_token']);
+        Telescope::hideRequestParameters([
+            '_token',
+            'password',
+            'password_confirmation',
+            'current_password',
+            'new_password',
+            'new_password_confirmation',
+            'token',
+            'access_token',
+            'api_token',
+        ]);
 
         Telescope::hideRequestHeaders([
+            'authorization',
             'cookie',
             'x-csrf-token',
             'x-xsrf-token',
+            'x-api-key',
         ]);
     }
 
@@ -56,10 +100,100 @@ class TelescopeServiceProvider extends TelescopeApplicationServiceProvider
      */
     protected function gate(): void
     {
-        Gate::define('viewTelescope', function ($user) {
-            return in_array($user->email, [
-                //
-            ]);
+        Gate::define('viewTelescope', function (?User $user = null): bool {
+            if ($user === null || $user->email_verified_at === null) {
+                return false;
+            }
+
+            $email = strtolower(trim((string) $user->email));
+
+            return in_array($email, $this->authorizedEmails(), true);
         });
+    }
+
+    /**
+     * Get the configured non-local operator emails or fail closed.
+     *
+     * @return list<string>
+     */
+    private function authorizedEmails(): array
+    {
+        $configured = config('telescope.authorized_emails');
+
+        if (! is_string($configured)) {
+            return [];
+        }
+
+        $emails = array_values(array_filter(
+            array_map('trim', explode(',', $configured)),
+            fn (string $email): bool => $email !== '',
+        ));
+
+        if ($emails === []) {
+            return [];
+        }
+
+        foreach ($emails as $email) {
+            if (filter_var($email, FILTER_VALIDATE_EMAIL) === false) {
+                return [];
+            }
+        }
+
+        return array_values(array_unique(array_map('strtolower', $emails)));
+    }
+
+    private function isErrorLog(IncomingEntry $entry): bool
+    {
+        if (! $entry->isLog()) {
+            return false;
+        }
+
+        return in_array(strtolower((string) ($entry->content['level'] ?? '')), [
+            LogLevel::ERROR,
+            LogLevel::CRITICAL,
+            LogLevel::ALERT,
+            LogLevel::EMERGENCY,
+        ], true);
+    }
+
+    /**
+     * Recursively remove credentials that top-level Telescope redaction misses.
+     */
+    private function redactSensitiveEntry(IncomingEntry $entry): void
+    {
+        if (! $entry->isRequest() && ! $entry->isLog()) {
+            return;
+        }
+
+        $redacted = false;
+        $entry->content = $this->redactSensitiveValues($entry->content, $redacted);
+
+        if ($entry->isLog() && $redacted) {
+            $entry->content['message'] = '[Redacted sensitive error log]';
+        }
+    }
+
+    /**
+     * @param  array<mixed>  $values
+     * @return array<mixed>
+     */
+    private function redactSensitiveValues(array $values, bool &$redacted): array
+    {
+        foreach ($values as $key => $value) {
+            $normalizedKey = str_replace('-', '_', strtolower((string) $key));
+
+            if (in_array($normalizedKey, self::SENSITIVE_KEYS, true)) {
+                $values[$key] = '********';
+                $redacted = true;
+
+                continue;
+            }
+
+            if (is_array($value)) {
+                $values[$key] = $this->redactSensitiveValues($value, $redacted);
+            }
+        }
+
+        return $values;
     }
 }

--- a/config/changelog.php
+++ b/config/changelog.php
@@ -3,6 +3,25 @@
 return [
     'releases' => [
         [
+            'version' => '2.0.7',
+            'status' => 'Released',
+            'released_at' => '2026-08-15',
+            'changes' => [
+                [
+                    'category' => 'Added',
+                    'description' => 'Added clearer project documentation and operational guidance.',
+                ],
+                [
+                    'category' => 'Changed',
+                    'description' => 'Improved error diagnostics and automatic retention cleanup.',
+                ],
+                [
+                    'category' => 'Security',
+                    'description' => 'Restricted diagnostic access and strengthened sensitive-data redaction.',
+                ],
+            ],
+        ],
+        [
             'version' => '2.0.6',
             'status' => 'Released',
             'released_at' => '2026-08-15',

--- a/config/telescope.php
+++ b/config/telescope.php
@@ -62,7 +62,19 @@ return [
     |
     */
 
-    'enabled' => env('TELESCOPE_ENABLED', false),
+    'enabled' => filter_var(
+        env('TELESCOPE_ENABLED', false),
+        FILTER_VALIDATE_BOOLEAN,
+        FILTER_NULL_ON_FAILURE,
+    ) ?? false,
+
+    'authorized_emails' => env('TELESCOPE_AUTHORIZED_EMAILS', ''),
+
+    'prune_hours' => filter_var(
+        env('TELESCOPE_PRUNE_HOURS', 168),
+        FILTER_VALIDATE_INT,
+        ['options' => ['min_range' => 1]],
+    ) ?: 168,
 
     /*
     |--------------------------------------------------------------------------

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,64 @@
+# Expenses App documentation
+
+This page maps each kind of project knowledge to one canonical source. Repository documentation describes approved, current behavior. GitHub Issues describe planned work until its implementation and documentation merge.
+
+## Documentation map
+
+| Topic | Canonical source | Status | Owner and update trigger |
+| --- | --- | --- | --- |
+| Product overview and quick start | [`README.md`](../README.md) | Current | Maintainers; update when supported setup or user-visible capabilities change. |
+| Documentation map and policy | [`docs/README.md`](README.md) | Current | Maintainers; update when a documentation category, owner, or canonical location changes. |
+| Release history | [`CHANGELOG.md`](../CHANGELOG.md) | Current from 2.0.6 | Release owner; update on every version aggregate. |
+| PostgreSQL 18 local upgrade | [`docs/postgresql-18-upgrade.md`](postgresql-18-upgrade.md) | Current | Platform owner; update when the supported PostgreSQL image or migration process changes. |
+| Domain language and financial rules | `docs/domain/` | Planned in [#57](https://github.com/lurzar/expenses-app/issues/57) | Domain owner; update when financial meaning, lifecycle, or invariants change. |
+| Stack, structure, architecture, conventions, integrations, testing, and concerns | `docs/codebase/` | Planned in [#66](https://github.com/lurzar/expenses-app/issues/66) | Technical owner; update when architecture or supported tooling changes. |
+| Web/Inertia interfaces and future API governance | `docs/interfaces/` | Planned in [#58](https://github.com/lurzar/expenses-app/issues/58) | Interface owner; update when routes, page props, authentication, or approved API contracts change. |
+| Development, validation, and release workflow | `docs/development/` | Planned in [#64](https://github.com/lurzar/expenses-app/issues/64) | Development owner; update when setup, quality gates, branching, versioning, or releases change. |
+| Error monitoring and operational response | `docs/operations/` | Planned in [#73](https://github.com/lurzar/expenses-app/issues/73) | Operations owner; update when monitoring, access, retention, incident response, or rollback changes. |
+| Architecture decisions | `docs/decisions/` | Reserved | Decision owner; add an ADR when an approved choice changes architecture, data, interfaces, or operations. |
+| Repository-wide AI-agent instructions | `AGENTS.md` | Planned in [#62](https://github.com/lurzar/expenses-app/issues/62) | Maintainers; update when repository rules, safety boundaries, or required checks change. |
+
+Planned paths are declarations, not links to implemented documents. Follow the linked issue for the approved scope and delivery status.
+
+## Information types
+
+Use the smallest document that serves the reader:
+
+- **Tutorials** teach a newcomer through a complete learning path.
+- **How-to guides** give steps for a specific operational or development task.
+- **Reference** records exact interfaces, commands, configuration, and structure.
+- **Explanation** documents domain meaning, architecture, and trade-offs.
+
+Keep each document focused on one information type where practical. Link related documents instead of copying their content.
+
+## Source-of-truth rules
+
+1. **Current behavior:** Verify claims against application source, configuration, routes, tests, or a reproducible command. Cite the relevant path or command in technical documents.
+2. **Planned behavior:** Link the GitHub issue. Never describe an unmerged feature, API, role, or operational capability as implemented.
+3. **Release state:** Use the repository changelog, verified tag, and release PR together. A version label alone does not prove delivery.
+4. **Decisions:** Mark an unresolved intent choice `[ASK USER]`. Mark known incomplete documentation or implementation `[TODO]` and link its issue when available.
+5. **Disagreement:** Source and verified commands override stale prose. Correct the document or issue in the same change that discovers the discrepancy.
+
+## Update policy
+
+Update documentation in the same issue and pull request when a change affects:
+
+- user-visible behavior or setup instructions;
+- domain terms, calculations, precision, or lifecycle rules;
+- architecture, module boundaries, dependencies, or integrations;
+- routes, Inertia props, authentication, authorization, or an approved API contract;
+- environment variables, monitoring, migrations, deployment, or rollback;
+- required validation, branch selection, versioning, or release metadata.
+
+The root README remains a concise entry point. Detailed project truth belongs in the canonical location listed above. Generated output, vendor documentation, issue comments, and AI-product adapters must not become competing sources.
+
+## Writing and review checklist
+
+- State the target reader and the task or question the document answers.
+- Separate current behavior from planned behavior.
+- Use concrete paths and verified commands for technical claims.
+- Include prerequisites, risks, and rollback where an operation changes data or infrastructure.
+- Keep credentials, personal data, production identifiers, and raw diagnostic details out of documentation.
+- Check relative links from the file that contains them.
+- Update this map when adding, moving, or retiring a canonical document.
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ This page maps each kind of project knowledge to one canonical source. Repositor
 | Development, validation, and release workflow | `docs/development/` | Planned in [#64](https://github.com/lurzar/expenses-app/issues/64) | Development owner; update when setup, quality gates, branching, versioning, or releases change. |
 | Error monitoring and operational response | `docs/operations/` | Planned in [#73](https://github.com/lurzar/expenses-app/issues/73) | Operations owner; update when monitoring, access, retention, incident response, or rollback changes. |
 | Architecture decisions | `docs/decisions/` | Reserved | Decision owner; add an ADR when an approved choice changes architecture, data, interfaces, or operations. |
-| Repository-wide AI-agent instructions | `AGENTS.md` | Planned in [#62](https://github.com/lurzar/expenses-app/issues/62) | Maintainers; update when repository rules, safety boundaries, or required checks change. |
+| Repository-wide AI-agent instructions | [`AGENTS.md`](../AGENTS.md) | Current | Maintainers; update when repository rules, safety boundaries, or required checks change. |
 
 Planned paths are declarations, not links to implemented documents. Follow the linked issue for the approved scope and delivery status.
 
@@ -61,4 +61,3 @@ The root README remains a concise entry point. Detailed project truth belongs in
 - Keep credentials, personal data, production identifiers, and raw diagnostic details out of documentation.
 - Check relative links from the file that contains them.
 - Update this map when adding, moving, or retiring a canonical document.
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ This page maps each kind of project knowledge to one canonical source. Repositor
 | Stack, structure, architecture, conventions, integrations, testing, and concerns | `docs/codebase/` | Planned in [#66](https://github.com/lurzar/expenses-app/issues/66) | Technical owner; update when architecture or supported tooling changes. |
 | Web/Inertia interfaces and future API governance | `docs/interfaces/` | Planned in [#58](https://github.com/lurzar/expenses-app/issues/58) | Interface owner; update when routes, page props, authentication, or approved API contracts change. |
 | Development, validation, and release workflow | `docs/development/` | Planned in [#64](https://github.com/lurzar/expenses-app/issues/64) | Development owner; update when setup, quality gates, branching, versioning, or releases change. |
-| Error monitoring and operational response | `docs/operations/` | Planned in [#73](https://github.com/lurzar/expenses-app/issues/73) | Operations owner; update when monitoring, access, retention, incident response, or rollback changes. |
+| Error monitoring and operational response | [`docs/operations/error-monitoring.md`](operations/error-monitoring.md) | Current | Operations owner; update when monitoring, access, retention, incident response, or rollback changes. |
 | Architecture decisions | `docs/decisions/` | Reserved | Decision owner; add an ADR when an approved choice changes architecture, data, interfaces, or operations. |
 | Repository-wide AI-agent instructions | [`AGENTS.md`](../AGENTS.md) | Current | Maintainers; update when repository rules, safety boundaries, or required checks change. |
 

--- a/docs/operations/error-monitoring.md
+++ b/docs/operations/error-monitoring.md
@@ -1,0 +1,126 @@
+# Error monitoring and incident response
+
+This how-to guide is for authorized Expenses App operators who need to inspect Laravel Telescope diagnostics, control retention, or respond to suspected diagnostic-data exposure. It documents the behavior implemented in [issue #36](https://github.com/lurzar/expenses-app/issues/36).
+
+> Telescope can contain personal data, application internals, queries, mail metadata, and stack traces. Use it only for a specific investigation. Never copy raw entries into issues, pull requests, chat, or documentation.
+
+## Implementation map
+
+Use the source as the authority when this guide and the application disagree:
+
+- [`.env.example`](../../.env.example) lists the supported environment variables.
+- [`config/telescope.php`](../../config/telescope.php) defines Telescope storage, paths, watchers, and validated defaults.
+- [`app/Providers/AppServiceProvider.php`](../../app/Providers/AppServiceProvider.php) controls provider registration.
+- [`app/Providers/TelescopeServiceProvider.php`](../../app/Providers/TelescopeServiceProvider.php) defines access, filtering, and redaction.
+- [`routes/console.php`](../../routes/console.php) defines scheduled pruning.
+- [`tests/Feature/System/TelescopeSecurityTest.php`](../../tests/Feature/System/TelescopeSecurityTest.php) verifies the security boundary.
+
+Activity/audit logging from [issue #34](https://github.com/lurzar/expenses-app/issues/34), role-based access, external alerting, and monitoring-vendor integrations are not implemented.
+
+## Understand the environment boundary
+
+In the `local` environment, the application registers Telescope even when `TELESCOPE_ENABLED` is false. Telescope then accepts entries allowed by the enabled watchers in `config/telescope.php`. This behavior supports local development only.
+
+In every non-local environment, the application registers Telescope only when `TELESCOPE_ENABLED` resolves to the boolean value `true`. Missing, false, or malformed values disable it. A malformed retention value falls back to 168 hours.
+
+Non-local filtering retains only:
+
+- reportable exceptions;
+- failed requests and jobs;
+- scheduled-task entries;
+- `error`, `critical`, `alert`, and `emergency` logs; and
+- entries with a monitored tag.
+
+Routine successful requests, debug logs, and other unmonitored noise are discarded. Enabled watchers may still collect sensitive application context before filtering, so application code must never put credentials into logs, exception messages, monitored tags, queries, or diagnostic strings.
+
+## Enable non-local diagnostics
+
+1. Select the smallest set of verified operator accounts needed for the investigation.
+2. Set these values through the environment-management process for the target deployment:
+
+   ```dotenv
+   TELESCOPE_ENABLED=true
+   TELESCOPE_AUTHORIZED_EMAILS=operator@example.test
+   TELESCOPE_PRUNE_HOURS=168
+   ```
+
+   `TELESCOPE_AUTHORIZED_EMAILS` accepts a comma-separated list. Every item must be a valid email address. An empty value or one malformed item denies access to everyone.
+
+3. Refresh the application's configuration using the deployment's normal configuration-cache procedure. For an uncached local verification environment, run:
+
+   ```bash
+   php artisan config:clear
+   ```
+
+4. Confirm that Telescope routes and daily pruning are registered:
+
+   ```bash
+   php artisan route:list --name=telescope
+   php artisan schedule:list
+   ```
+
+5. Sign in with an allowlisted account whose email is verified, then open `/telescope`. Guests, unverified users, and users outside the allowlist receive `403 Forbidden`.
+
+Do not enable Telescope until the allowlist and scheduled pruning are both verified.
+
+## Inspect an incident safely
+
+1. Record the user-visible symptom, approximate time window, affected feature, and a non-sensitive correlation value such as an internal request identifier.
+2. Open Telescope with a verified, allowlisted account.
+3. Search the narrowest time window and entry category that matches the symptom.
+4. Start with the failed request, exception, failed job, or error-level log. Follow related entries only when needed.
+5. Record conclusions and sanitized identifiers. Paraphrase error details; never export a raw payload, stack trace, query, mail body, cookie, token, or user record.
+6. Apply the smallest application fix, then reproduce the original operation in a safe environment.
+7. Confirm the user-visible behavior and relevant automated checks before closing the incident.
+8. Remove temporary access and disable non-local Telescope when the investigation ends.
+
+Request parameters and headers with known credential keys are hidden. Retained request and log structures also receive recursive credential-key redaction. If a retained log context contains a credential field, Telescope replaces the rendered message because interpolation may have copied the value. Safe diagnostic fields remain available.
+
+Redaction reduces risk; it does not make Telescope an approved store for secrets. Arbitrary credentials embedded in free-form strings or unexpected data shapes cannot be classified reliably.
+
+## Prune diagnostic data
+
+The scheduler runs daily and retains the configured number of hours. It uses a lock to prevent overlapping prune jobs. Confirm the scheduler itself runs through the deployment's existing scheduler process; this repository does not define or deploy that infrastructure.
+
+To run the documented retention policy manually, execute:
+
+```bash
+php artisan telescope:prune --hours=168
+```
+
+Replace `168` only with an approved positive retention value. Pruning permanently deletes older Telescope entries. Confirm the target environment and retention window before running the command.
+
+During a confirmed diagnostic-data exposure, an incident owner may approve a full Telescope purge:
+
+```bash
+php artisan telescope:prune --hours=0
+```
+
+Run the purge before disabling the provider, or use an approved one-command configuration override. Treat this as destructive: preserve only sanitized incident evidence required by policy, and never copy the exposed raw data elsewhere.
+
+## Disable or roll back Telescope
+
+1. Set `TELESCOPE_ENABLED=false` in the target environment.
+2. Refresh the application's configuration cache through the deployment's normal procedure.
+3. Run `php artisan route:list --name=telescope`. The application must expose no Laravel Telescope routes. An unrelated Debugbar route named `debugbar.telescope` may appear in development tooling.
+4. Run `php artisan schedule:list` and confirm the Telescope prune schedule is absent outside `local`.
+5. Revoke any temporary operational access granted for the investigation.
+
+Disabling Telescope stops new application registration and capture; it does not delete existing database entries. Prune retained entries separately when policy or an incident requires deletion.
+
+To roll back the code change, revert the Telescope implementation pull request through the normal release process and leave `TELESCOPE_ENABLED=false`. Re-enable it only after the focused Telescope security tests and access checks pass.
+
+## Respond to suspected exposure
+
+1. Contain capture by disabling Telescope, unless a full purge must run first.
+2. Restrict application and database access to the incident responders.
+3. Determine the affected time window, entry types, users, environments, and credential classes without reproducing raw values.
+4. Rotate a credential when a Telescope entry may contain its value, when exposure cannot be ruled out, or when an unauthorized person could access the diagnostic store. This includes session cookies, API tokens, authorization headers, CSRF tokens, passwords, and infrastructure credentials.
+5. Invalidate active sessions or tokens when their secrets may be exposed.
+6. Prune the affected Telescope data with incident-owner approval.
+7. Validate that Telescope routes are absent, capture has stopped, and the affected credentials no longer work.
+8. Fix the source that logged or attached the sensitive value. Add a regression test when the application boundary should have removed it.
+9. Record a sanitized incident summary, decisions, rotations, validation, and follow-up issue links.
+10. Re-enable non-local diagnostics only after security review and operator-access verification.
+
+If the implementation behavior is uncertain, keep Telescope disabled, correct this canonical guide and the related issue, and repeat the security checks before restoring access.

--- a/routes/console.php
+++ b/routes/console.php
@@ -13,4 +13,14 @@ use Illuminate\Support\Facades\Schedule;
 |
 */
 
-Schedule::command('telescope:prune --hours=1')->everyThreeMinutes();
+if (app()->environment('local') || config('telescope.enabled') === true) {
+    $retentionHours = filter_var(
+        config('telescope.prune_hours', 168),
+        FILTER_VALIDATE_INT,
+        ['options' => ['min_range' => 1]],
+    ) ?: 168;
+
+    Schedule::command("telescope:prune --hours={$retentionHours}")
+        ->daily()
+        ->withoutOverlapping();
+}

--- a/tests/Feature/System/TelescopeSecurityTest.php
+++ b/tests/Feature/System/TelescopeSecurityTest.php
@@ -1,0 +1,269 @@
+<?php
+
+use App\Models\User;
+use App\Providers\AppServiceProvider;
+use App\Providers\TelescopeServiceProvider as AppTelescopeServiceProvider;
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Str;
+use Laravel\Telescope\EntryType;
+use Laravel\Telescope\IncomingEntry;
+use Laravel\Telescope\Telescope;
+use Laravel\Telescope\TelescopeServiceProvider;
+
+beforeEach(function () {
+    Telescope::$filterUsing = [];
+    Telescope::$hiddenRequestHeaders = ['authorization', 'php-auth-pw'];
+    Telescope::$hiddenRequestParameters = ['password', 'password_confirmation'];
+});
+
+function useNonLocalEnvironment(): void
+{
+    app()->detectEnvironment(fn () => 'production');
+}
+
+function registerApplicationTelescopeProvider(): void
+{
+    $provider = new AppTelescopeServiceProvider(app());
+    $provider->register();
+    $provider->boot();
+}
+
+test('non-local telescope registration follows loaded configuration', function () {
+    useNonLocalEnvironment();
+    config()->set('telescope.enabled', true);
+
+    (new AppServiceProvider(app()))->register();
+
+    expect(app()->getProvider(TelescopeServiceProvider::class))->not->toBeNull()
+        ->and(app()->getProvider(AppTelescopeServiceProvider::class))->not->toBeNull();
+});
+
+test('non-local telescope remains unregistered when loaded configuration disables it', function () {
+    useNonLocalEnvironment();
+    config()->set('telescope.enabled', false);
+
+    (new AppServiceProvider(app()))->register();
+
+    expect(app()->getProvider(TelescopeServiceProvider::class))->toBeNull()
+        ->and(app()->getProvider(AppTelescopeServiceProvider::class))->toBeNull();
+});
+
+test('non-local telescope fails closed when loaded enablement is malformed', function () {
+    useNonLocalEnvironment();
+    config()->set('telescope.enabled', 'typo');
+
+    (new AppServiceProvider(app()))->register();
+
+    expect(app()->getProvider(TelescopeServiceProvider::class))->toBeNull()
+        ->and(app()->getProvider(AppTelescopeServiceProvider::class))->toBeNull();
+});
+
+test('local telescope remains available when its loaded configuration is disabled', function () {
+    app()->detectEnvironment(fn () => 'local');
+    config()->set('telescope.enabled', false);
+
+    (new AppServiceProvider(app()))->register();
+
+    expect(app()->getProvider(TelescopeServiceProvider::class))->not->toBeNull()
+        ->and(app()->getProvider(AppTelescopeServiceProvider::class))->not->toBeNull();
+});
+
+test('non-local telescope routes deny guests when enabled', function () {
+    useNonLocalEnvironment();
+    config()->set([
+        'telescope.enabled' => true,
+        'telescope.authorized_emails' => 'operator@example.com',
+    ]);
+
+    (new AppServiceProvider(app()))->register();
+
+    $this->get('/telescope')->assertForbidden();
+});
+
+test('a verified allowlisted operator can view non-local telescope', function () {
+    useNonLocalEnvironment();
+    config()->set('telescope.authorized_emails', ' first@example.com, OPERATOR@example.com ');
+    registerApplicationTelescopeProvider();
+    $operator = User::factory()->create(['email' => 'operator@example.com']);
+
+    expect(Gate::forUser($operator)->allows('viewTelescope'))->toBeTrue();
+});
+
+test('non-local telescope rejects unverified unlisted and malformed authorization', function () {
+    useNonLocalEnvironment();
+    $verified = User::factory()->create(['email' => 'operator@example.com']);
+    $unverified = User::factory()->unverified()->create(['email' => 'unverified@example.com']);
+
+    config()->set('telescope.authorized_emails', 'other@example.com');
+    registerApplicationTelescopeProvider();
+    expect(Gate::forUser($verified)->allows('viewTelescope'))->toBeFalse();
+
+    config()->set('telescope.authorized_emails', 'operator@example.com,not-an-email');
+    registerApplicationTelescopeProvider();
+    expect(Gate::forUser($verified)->allows('viewTelescope'))->toBeFalse();
+
+    config()->set('telescope.authorized_emails', 'unverified@example.com');
+    registerApplicationTelescopeProvider();
+    expect(Gate::forUser($unverified)->allows('viewTelescope'))->toBeFalse();
+});
+
+test('non-local request diagnostics redact approved credentials and headers', function () {
+    useNonLocalEnvironment();
+    registerApplicationTelescopeProvider();
+
+    expect(Telescope::$hiddenRequestParameters)->toContain(
+        '_token',
+        'password',
+        'password_confirmation',
+        'current_password',
+        'token',
+        'access_token',
+        'api_token',
+    )->and(Telescope::$hiddenRequestHeaders)->toContain(
+        'authorization',
+        'cookie',
+        'x-csrf-token',
+        'x-xsrf-token',
+        'x-api-key',
+    );
+});
+
+test('non-local retained requests recursively redact nested credentials', function () {
+    useNonLocalEnvironment();
+    registerApplicationTelescopeProvider();
+    $filter = Telescope::$filterUsing[array_key_last(Telescope::$filterUsing)];
+    $request = IncomingEntry::make([
+        'response_status' => 500,
+        'payload' => [
+            'credentials' => [
+                'password' => 'nested-password',
+                'token' => 'nested-token',
+            ],
+            'safe' => 'diagnostic-value',
+        ],
+        'session' => [
+            'nested' => ['access-token' => 'session-token'],
+        ],
+        'headers' => [
+            'x-api-key' => 'request-api-key',
+        ],
+    ])->type(EntryType::REQUEST);
+
+    expect($filter($request))->toBeTrue()
+        ->and($request->content['payload']['credentials']['password'])->toBe('********')
+        ->and($request->content['payload']['credentials']['token'])->toBe('********')
+        ->and($request->content['session']['nested']['access-token'])->toBe('********')
+        ->and($request->content['headers']['x-api-key'])->toBe('********')
+        ->and($request->content['payload']['safe'])->toBe('diagnostic-value');
+});
+
+test('non-local retained error logs redact nested context and interpolated messages', function () {
+    useNonLocalEnvironment();
+    registerApplicationTelescopeProvider();
+    $filter = Telescope::$filterUsing[array_key_last(Telescope::$filterUsing)];
+    $log = IncomingEntry::make([
+        'level' => 'error',
+        'message' => 'Authentication failed with token raw-log-token',
+        'context' => [
+            'credentials' => ['token' => 'raw-log-token'],
+            'safe' => 'diagnostic-value',
+        ],
+    ])->type(EntryType::LOG);
+
+    expect($filter($log))->toBeTrue()
+        ->and($log->content['context']['credentials']['token'])->toBe('********')
+        ->and($log->content['message'])->not->toContain('raw-log-token')
+        ->and($log->content['context']['safe'])->toBe('diagnostic-value');
+});
+
+test('non-local filtering retains failures and error logs without routine noise', function () {
+    useNonLocalEnvironment();
+    registerApplicationTelescopeProvider();
+    $filter = Telescope::$filterUsing[array_key_last(Telescope::$filterUsing)];
+
+    $failedRequest = IncomingEntry::make(['response_status' => 500])->type(EntryType::REQUEST);
+    $failedJob = IncomingEntry::make(['status' => 'failed'])->type(EntryType::JOB);
+    $errorLog = IncomingEntry::make(['level' => 'error'])->type(EntryType::LOG);
+    $debugLog = IncomingEntry::make(['level' => 'debug'])->type(EntryType::LOG);
+    $successfulRequest = IncomingEntry::make(['response_status' => 200])->type(EntryType::REQUEST);
+
+    expect($filter($failedRequest))->toBeTrue()
+        ->and($filter($failedJob))->toBeTrue()
+        ->and($filter($errorLog))->toBeTrue()
+        ->and($filter($debugLog))->toBeFalse()
+        ->and($filter($successfulRequest))->toBeFalse();
+});
+
+test('disabled telescope has no pruning schedule', function () {
+    $pruneEvents = collect(app(Schedule::class)->events())
+        ->filter(fn ($event) => Str::contains($event->command ?? '', 'telescope:prune'));
+
+    expect($pruneEvents)->toBeEmpty();
+});
+
+test('enabled telescope uses configured daily pruning', function () {
+    config()->set([
+        'telescope.enabled' => true,
+        'telescope.prune_hours' => 168,
+    ]);
+
+    require base_path('routes/console.php');
+
+    $event = collect(app(Schedule::class)->events())
+        ->first(fn ($event) => Str::contains($event->command ?? '', 'telescope:prune --hours=168'));
+
+    expect($event)->not->toBeNull()
+        ->and($event->expression)->toBe('0 0 * * *');
+});
+
+test('malformed pruning retention fails closed to the documented default', function () {
+    config()->set([
+        'telescope.enabled' => true,
+        'telescope.prune_hours' => 'invalid',
+    ]);
+
+    require base_path('routes/console.php');
+
+    $event = collect(app(Schedule::class)->events())
+        ->first(fn ($event) => Str::contains($event->command ?? '', 'telescope:prune --hours=168'));
+
+    expect($event)->not->toBeNull();
+});
+
+test('configured pruning deletes expired entries and retains recent entries', function () {
+    useNonLocalEnvironment();
+    config()->set('telescope.enabled', true);
+    (new AppServiceProvider(app()))->register();
+
+    DB::table('telescope_entries')->insert([
+        [
+            'uuid' => (string) Str::uuid(),
+            'batch_id' => (string) Str::uuid(),
+            'type' => EntryType::LOG,
+            'content' => '{}',
+            'created_at' => now()->subHours(169),
+        ],
+        [
+            'uuid' => (string) Str::uuid(),
+            'batch_id' => (string) Str::uuid(),
+            'type' => EntryType::LOG,
+            'content' => '{}',
+            'created_at' => now()->subHours(167),
+        ],
+    ]);
+
+    $this->artisan('telescope:prune', ['--hours' => 168])->assertSuccessful();
+
+    expect(DB::table('telescope_entries')->count())->toBe(1);
+});
+
+test('example environment documents safe telescope controls', function () {
+    $environment = file_get_contents(base_path('.env.example'));
+
+    expect($environment)->toContain(
+        'TELESCOPE_AUTHORIZED_EMAILS=',
+        'TELESCOPE_PRUNE_HOURS=168',
+    );
+});


### PR DESCRIPTION
## Version intent

Aggregate the completed v2.0.7 documentation-first observability release into `v2.1`.

## Included work

- [x] PR #74 / #59 — establish the repository documentation source of truth
- [x] PR #75 / #62 — add repository-wide AI-agent guidance
- [x] PR #77 / #36 — secure Telescope diagnostics, access, redaction, filtering, and retention
- [x] PR #78 / #73 — document error monitoring and incident response
- [x] Finalize `CHANGELOG.md` and the public `config/changelog.php` entry

## Compatibility and operational notes

- This patch adds no public API, database migration, dependency, or production-deployment change.
- Local Telescope behavior remains available for development.
- Non-local Telescope registration now requires explicit boolean enablement.
- Non-local access requires an authenticated, verified user whose email appears in the environment allowlist; empty or malformed configuration denies everyone.
- Daily pruning retains 168 hours by default. Operators must keep the deployment scheduler running.
- The canonical operations guide is `docs/operations/error-monitoring.md`.

## Aggregate validation

Validated on exact remote v2.0.7 tree `6157d6e100c8717fa35c3ea5839dac52ff6bd2f7`:

- [x] release-focused auth and Telescope tests — 20 passed, 83 assertions
- [x] changed PHP file Pint — passed
- [x] repository and aggregate `git diff --check` — passed
- [x] Composer validation — valid
- [x] Composer audit — no advisories
- [x] npm audit — 0 vulnerabilities
- [x] TypeScript — no errors
- [x] Vite production build — 797 modules transformed
- [x] route inventory — 28 application routes
- [x] daily Telescope prune schedule — `telescope:prune --hours=168`
- [x] cached and uncached configuration schedule behavior — matched
- [x] security review — reproduced and fixed the nested credential-redaction finding; regression coverage passes
- [ ] full isolated backend suite — 36 passed, 5 known baseline failures
- [ ] repository-wide Pint — inherited style findings remain outside the changed PHP files

## Known residual issues

The five backend failures match the established baseline tracked in #65 and are not introduced by v2.0.7:

- missing `auth.verify-email`, `auth.confirm-password`, `auth.forgot-password`, and `auth.reset-password` Blade views; and
- the profile deletion test expects hard deletion while the user model uses soft deletion.

Repository-wide Pint reports existing findings across legacy application, module, configuration, factory, seeder, and test files. Every PHP file changed by this release passes Pint.

## Security and data integrity

- The master enable switch, verified-operator allowlist, and access gate remain separate fail-closed controls.
- Known credential parameters and headers receive top-level and recursive redaction on retained request and log entries.
- Sensitive interpolated log messages are replaced when their context required redaction.
- Routine successful requests and debug/noise logs are excluded outside local development.
- The operator guide warns that Telescope remains sensitive and documents containment, pruning, secret rotation, validation, and rollback.

## Deployment and rollback

- No production deployment is part of this PR.
- Leave `TELESCOPE_ENABLED=false` outside local unless an authorized investigation requires diagnostics.
- Roll back application code by reverting this aggregate merge.
- If diagnostics may have exposed sensitive data, disable Telescope, rotate affected secrets, and prune Telescope entries through the documented incident flow.

## Release metadata

- Create the repository-convention lightweight tag `v2.0.7-dev` on the `v2.1` squash-merge commit.
- Verify the remote tag and use the `CHANGELOG.md` section as the release-note source.
- No GitHub Release object is planned; recent patch versions use lightweight Git tags.

Closes #36
Closes #59
Closes #62
Closes #72
Closes #73
Refs #39 and #67
