### PR TITLE
Perf: Cache user Planning collections (#35)

### DIFF
--- a/app/Modules/Planning/PlanningServiceProvider.php
+++ b/app/Modules/Planning/PlanningServiceProvider.php
@@ -4,6 +4,7 @@ namespace App\Modules\Planning;
 
 use App\Modules\ActivityLog\Services\ActivityRecorder;
 use App\Modules\Planning\Models\Planning;
+use App\Modules\Planning\Services\PlanningCache;
 use App\Modules\Planning\Services\PlanningService;
 use Illuminate\Support\ServiceProvider;
 
@@ -15,7 +16,11 @@ class PlanningServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->singleton(PlanningService::class, function ($app) {
-            return new PlanningService(new Planning, $app->make(ActivityRecorder::class));
+            return new PlanningService(
+                new Planning,
+                $app->make(ActivityRecorder::class),
+                $app->make(PlanningCache::class),
+            );
         });
     }
 

--- a/app/Modules/Planning/Services/PlanningCache.php
+++ b/app/Modules/Planning/Services/PlanningCache.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Modules\Planning\Services;
+
+use Closure;
+use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Support\Collection;
+
+final class PlanningCache
+{
+    private const INDEX_KEY_VERSION = 'v1';
+
+    private const INDEX_TTL_SECONDS = 300;
+
+    public function __construct(
+        private readonly Repository $cache,
+    ) {}
+
+    /**
+     * Return the cached Planning collection for one authenticated user.
+     *
+     * @param  Closure(): Collection<int, mixed>  $load
+     * @return Collection<int, mixed>
+     */
+    public function rememberIndex(int $userId, Closure $load): Collection
+    {
+        return $this->cache->remember(
+            $this->indexKey($userId),
+            self::INDEX_TTL_SECONDS,
+            $load,
+        );
+    }
+
+    public function forgetIndex(int $userId): bool
+    {
+        return $this->cache->forget($this->indexKey($userId));
+    }
+
+    public function indexKey(int $userId): string
+    {
+        return sprintf(
+            'planning:index:%s:user:%d',
+            self::INDEX_KEY_VERSION,
+            $userId,
+        );
+    }
+}

--- a/app/Modules/Planning/Services/PlanningService.php
+++ b/app/Modules/Planning/Services/PlanningService.php
@@ -14,6 +14,7 @@ class PlanningService
     public function __construct(
         private Planning $model,
         private ActivityRecorder $activityRecorder,
+        private PlanningCache $cache,
     ) {}
 
     /**
@@ -21,7 +22,7 @@ class PlanningService
      */
     public function store(Collection $planning): Planning
     {
-        return DB::transaction(function () use ($planning): Planning {
+        $storedPlanning = DB::transaction(function () use ($planning): Planning {
             $this->handleRequest($planning);
 
             $this->model->user_id = Auth::id();
@@ -41,6 +42,10 @@ class PlanningService
 
             return $this->model;
         });
+
+        $this->cache->forgetIndex((int) $storedPlanning->user_id);
+
+        return $storedPlanning;
     }
 
     /**
@@ -48,6 +53,8 @@ class PlanningService
      */
     public function delete(Planning $planning): void
     {
+        $userId = (int) $planning->user_id;
+
         DB::transaction(function () use ($planning): void {
             $planning->delete();
 
@@ -58,6 +65,8 @@ class PlanningService
                 $planning->planning_id,
             );
         });
+
+        $this->cache->forgetIndex($userId);
     }
 
     /**
@@ -65,10 +74,19 @@ class PlanningService
      */
     public function getAllPlannings(): Collection
     {
-        return $this->model
-            ->where('user_id', Auth::id())
-            ->latest()
-            ->get();
+        $userId = Auth::id();
+
+        if ($userId === null) {
+            return collect();
+        }
+
+        return $this->cache->rememberIndex(
+            $userId,
+            fn (): Collection => $this->model
+                ->where('user_id', $userId)
+                ->latest()
+                ->get(),
+        );
     }
 
     /**

--- a/app/Modules/Profile/Controllers/ProfileController.php
+++ b/app/Modules/Profile/Controllers/ProfileController.php
@@ -5,6 +5,7 @@ namespace App\Modules\Profile\Controllers;
 use App\Http\Controllers\Controller;
 use App\Modules\ActivityLog\ActivityEvent;
 use App\Modules\ActivityLog\Services\ActivityRecorder;
+use App\Modules\Planning\Services\PlanningCache;
 use App\Modules\Profile\Requests\ProfileUpdateRequest;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Http\RedirectResponse;
@@ -19,6 +20,7 @@ class ProfileController extends Controller
 {
     public function __construct(
         private readonly ActivityRecorder $activityRecorder,
+        private readonly PlanningCache $planningCache,
     ) {}
 
     /**
@@ -86,6 +88,8 @@ class ProfileController extends Controller
                 $user->user_id,
             );
         });
+
+        $this->planningCache->forgetIndex((int) $user->getKey());
 
         Auth::logout();
 

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -3,9 +3,14 @@
 namespace App\Observers;
 
 use App\Models\User;
+use App\Modules\Planning\Services\PlanningCache;
 
 class UserObserver
 {
+    public function __construct(
+        private readonly PlanningCache $planningCache,
+    ) {}
+
     /**
      * Handle the User "deleted" event.
      * Cascade soft-delete to related plannings.
@@ -22,5 +27,6 @@ class UserObserver
     public function restored(User $user): void
     {
         $user->plannings()->withTrashed()->restore();
+        $this->planningCache->forgetIndex((int) $user->getKey());
     }
 }

--- a/tests/Feature/Planning/PlanningCacheTest.php
+++ b/tests/Feature/Planning/PlanningCacheTest.php
@@ -1,0 +1,207 @@
+<?php
+
+use App\Models\User;
+use App\Modules\ActivityLog\Services\ActivityRecorder;
+use App\Modules\Planning\Models\Planning;
+use App\Modules\Planning\Services\PlanningCache;
+use App\Modules\Planning\Services\PlanningService;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Support\Facades\Cache;
+use Mockery\MockInterface;
+
+beforeEach(function (): void {
+    Cache::flush();
+});
+
+test('repeated planning collection reads use the cached result', function () {
+    $user = User::factory()->create();
+    $original = Planning::factory()->for($user)->create();
+
+    $this->actingAs($user);
+
+    $firstRead = app(PlanningService::class)->getAllPlannings();
+    Planning::factory()->for($user)->create();
+    $secondRead = app(PlanningService::class)->getAllPlannings();
+
+    expect($firstRead->modelKeys())->toBe([$original->getKey()])
+        ->and($secondRead->modelKeys())->toBe([$original->getKey()]);
+});
+
+test('planning collection cache entries are isolated by authenticated user', function () {
+    $firstUser = User::factory()->create();
+    $secondUser = User::factory()->create();
+    $firstPlanning = Planning::factory()->for($firstUser)->create();
+    $secondPlanning = Planning::factory()->for($secondUser)->create();
+
+    $this->actingAs($firstUser);
+    $firstResult = app(PlanningService::class)->getAllPlannings();
+
+    $this->actingAs($secondUser);
+    $secondResult = app(PlanningService::class)->getAllPlannings();
+
+    expect($firstResult->modelKeys())->toBe([$firstPlanning->getKey()])
+        ->and($secondResult->modelKeys())->toBe([$secondPlanning->getKey()]);
+});
+
+test('empty planning collections are cached', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user);
+
+    expect(app(PlanningService::class)->getAllPlannings())->toBeEmpty();
+
+    Planning::factory()->for($user)->create();
+
+    expect(app(PlanningService::class)->getAllPlannings())->toBeEmpty();
+});
+
+test('planning collection cache expires after five minutes', function () {
+    $user = User::factory()->create();
+    $original = Planning::factory()->for($user)->create();
+
+    $this->actingAs($user);
+
+    expect(app(PlanningService::class)->getAllPlannings()->modelKeys())
+        ->toBe([$original->getKey()]);
+
+    $newPlanning = Planning::factory()->for($user)->create();
+
+    expect(app(PlanningService::class)->getAllPlannings()->modelKeys())
+        ->toBe([$original->getKey()]);
+
+    $this->travel(301)->seconds();
+
+    expect(app(PlanningService::class)->getAllPlannings()->modelKeys())
+        ->toContain($original->getKey(), $newPlanning->getKey());
+});
+
+test('creating a planning invalidates the authenticated user collection', function () {
+    $user = User::factory()->create();
+    $original = Planning::factory()->for($user)->create();
+
+    $this->actingAs($user);
+
+    expect(app(PlanningService::class)->getAllPlannings()->modelKeys())
+        ->toBe([$original->getKey()]);
+
+    $this->post(route('planning.store'), validPlanningCachePayload())
+        ->assertRedirect(route('planning.index'));
+
+    expect(app(PlanningService::class)->getAllPlannings())
+        ->toHaveCount(2);
+});
+
+test('deleting a planning invalidates the authenticated user collection', function () {
+    $user = User::factory()->create();
+    $planning = Planning::factory()->for($user)->create();
+
+    $this->actingAs($user);
+
+    expect(app(PlanningService::class)->getAllPlannings()->modelKeys())
+        ->toBe([$planning->getKey()]);
+
+    $this->delete(route('planning.destroy', $planning))
+        ->assertRedirect(route('planning.index'));
+
+    expect(app(PlanningService::class)->getAllPlannings())
+        ->toBeEmpty();
+});
+
+test('planning mutations retain other users collection entries', function () {
+    $firstUser = User::factory()->create();
+    $secondUser = User::factory()->create();
+    Planning::factory()->for($firstUser)->create();
+    Planning::factory()->for($secondUser)->create();
+
+    $cache = app(PlanningCache::class);
+
+    $this->actingAs($firstUser);
+    app(PlanningService::class)->getAllPlannings();
+
+    $this->actingAs($secondUser);
+    app(PlanningService::class)->getAllPlannings();
+
+    $this->actingAs($firstUser)
+        ->post(route('planning.store'), validPlanningCachePayload())
+        ->assertRedirect(route('planning.index'));
+
+    expect(Cache::has($cache->indexKey($firstUser->getKey())))->toBeFalse()
+        ->and(Cache::has($cache->indexKey($secondUser->getKey())))->toBeTrue();
+});
+
+test('deleting an account invalidates its planning collection', function () {
+    $user = User::factory()->create();
+    Planning::factory()->for($user)->create();
+
+    $this->actingAs($user);
+    app(PlanningService::class)->getAllPlannings();
+
+    $key = app(PlanningCache::class)->indexKey($user->getKey());
+
+    expect(Cache::has($key))->toBeTrue();
+
+    $this->delete(route('profile.destroy'), ['password' => 'password'])
+        ->assertRedirect('/');
+
+    expect(Cache::has($key))->toBeFalse();
+});
+
+test('restoring an account invalidates its planning collection', function () {
+    $user = User::factory()->create();
+    $key = app(PlanningCache::class)->indexKey($user->getKey());
+
+    $user->delete();
+    Cache::put($key, collect(['stale']), 300);
+
+    $user->restore();
+
+    expect(Cache::has($key))->toBeFalse();
+});
+
+test('a rolled back planning mutation retains the existing cache entry', function () {
+    $user = User::factory()->create();
+    $planning = Planning::factory()->for($user)->create();
+    $cache = app(PlanningCache::class);
+    $key = $cache->indexKey($user->getKey());
+
+    Cache::put($key, new EloquentCollection([$planning]), 300);
+
+    $this->mock(ActivityRecorder::class, function (MockInterface $mock): void {
+        $mock->shouldReceive('record')
+            ->once()
+            ->andThrow(new RuntimeException('Activity recorder unavailable'));
+    });
+
+    $this->withoutExceptionHandling();
+
+    expect(fn () => $this->actingAs($user)->post(
+        route('planning.store'),
+        validPlanningCachePayload(),
+    ))->toThrow(RuntimeException::class, 'Activity recorder unavailable');
+
+    expect(Cache::has($key))->toBeTrue()
+        ->and(Cache::get($key)->modelKeys())->toBe([$planning->getKey()]);
+
+    $this->assertDatabaseCount('plannings', 1);
+});
+
+/**
+ * @return array<string, mixed>
+ */
+function validPlanningCachePayload(): array
+{
+    return [
+        'month' => 'August',
+        'year' => '2026',
+        'salary' => '5000.00',
+        'saving_rate' => '10',
+        'totals' => [
+            'savings' => '500.00',
+            'commitments' => '1500.00',
+            'others' => '500.00',
+        ],
+        'savings_values' => [],
+        'commitments_values' => [],
+        'others_values' => [],
+    ];
+}


### PR DESCRIPTION
## Summary

Cache the authenticated user's Planning collection for Dashboard, Planning, and Expenses index reads. Keep the database query as the authorization boundary, use a versioned per-user key with a five-minute TTL, and invalidate only after successful mutations.

Closes #35

## Changes

- Add a store-neutral `PlanningCache` boundary using Laravel's configured default cache repository.
- Cache empty and populated Planning collections under per-user keys.
- Invalidate after successful Planning create/delete and account delete/restore flows.
- Keep single-record reads, route-model binding, authentication, profiles, activity logs, Telescope, validation failures, and error responses outside the cache.
- Add ten focused tests for hits, expiry, isolation, invalidation, unaffected users, and rollback behavior.

## Validation

- Focused Planning cache suite — 10 passed, 33 assertions.
- Affected Planning/Profile/activity suite — 35 passed; one inherited Profile soft-delete expectation failed as tracked by #65.
- Full isolated backend suite — 67 passed, 5 known #65 baseline failures.
- Changed-file Pint — passed.
- Repository-wide Pint — the unchanged #65 baseline remains across 35 legacy files.
- Composer validation — valid.
- Composer audit — no advisories.
- TypeScript — no errors.
- Vite production build — 797 modules transformed.
- npm audit — 0 vulnerabilities.
- Diff security review — complete coverage of all five changed source files; no reportable findings.
- Browser smoke — omitted because this change adds no UI or route contract.

## Risks and rollback

- Risk: malformed keys could expose Planning data across users; per-user keys and two-user tests cover this boundary.
- Risk: missed invalidation could show stale data; all current Planning and account mutation paths have focused tests.
- Rollback: revert this PR. It adds no schema, dependency, environment variable, or stored-data migration.

## Dependencies and rollout

- Base/release target: `v2.0.9`.
- #87 documents the merged cache behavior and stacks above this branch.
- Refs #88 for release aggregation, #61 for independent single-record ownership work, and #65 for inherited quality-gate failures.

## Out of scope / known limitations

- Redis remains optional; the repository's configured default cache store remains unchanged.
- This PR does not change single-record authorization, add cache tags, add a cache UI/API, or resolve #61/#65.

