### PR TITLE
Implement Planning financial summaries and graphs (#124)

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -38,6 +38,7 @@ class HandleInertiaRequests extends Middleware
             'flash' => [
                 'message' => fn () => $request->session()->get('message'),
                 'success' => fn () => $request->session()->get('success'),
+                'warning' => fn () => $request->session()->get('warning'),
                 'error' => fn () => $request->session()->get('error'),
             ],
         ];

--- a/app/Modules/Planning/Controllers/PlanningController.php
+++ b/app/Modules/Planning/Controllers/PlanningController.php
@@ -54,11 +54,18 @@ class PlanningController extends Controller
         $name = $planning->name;
 
         try {
-            $this->service->delete($planning);
+            $cacheInvalidated = $this->service->delete($planning);
         } catch (Throwable $exception) {
             report($exception);
 
             return back()->with('error', 'The plan could not be deleted. Try again.');
+        }
+
+        if (! $cacheInvalidated) {
+            return redirect()->route('planning.index')->with(
+                'warning',
+                "{$name} plan deleted. Planning lists may take up to five minutes to refresh.",
+            );
         }
 
         return redirect()->route('planning.index')->with('success', "{$name} plan deleted.");

--- a/app/Modules/Planning/Controllers/PlanningController.php
+++ b/app/Modules/Planning/Controllers/PlanningController.php
@@ -11,6 +11,7 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Gate;
 use Inertia\Inertia;
 use Inertia\Response;
+use Throwable;
 
 class PlanningController extends Controller
 {
@@ -50,8 +51,16 @@ class PlanningController extends Controller
     {
         Gate::authorize('delete', $planning);
 
-        $this->service->delete($planning);
+        $name = $planning->name;
 
-        return redirect()->route('planning.index');
+        try {
+            $this->service->delete($planning);
+        } catch (Throwable $exception) {
+            report($exception);
+
+            return back()->with('error', 'The plan could not be deleted. Try again.');
+        }
+
+        return redirect()->route('planning.index')->with('success', "{$name} plan deleted.");
     }
 }

--- a/app/Modules/Planning/Services/PlanningService.php
+++ b/app/Modules/Planning/Services/PlanningService.php
@@ -9,6 +9,7 @@ use App\Modules\Planning\Support\PlanningCalculator;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Throwable;
 
 class PlanningService
 {
@@ -56,7 +57,7 @@ class PlanningService
             return $storedPlanning;
         });
 
-        $this->cache->forgetIndex((int) $storedPlanning->user_id);
+        $this->forgetIndexAfterCommit((int) $storedPlanning->user_id);
 
         return $storedPlanning;
     }
@@ -64,7 +65,7 @@ class PlanningService
     /**
      * Soft-delete a planning record and its activity atomically.
      */
-    public function delete(Planning $planning): void
+    public function delete(Planning $planning): bool
     {
         $userId = (int) $planning->user_id;
 
@@ -79,7 +80,7 @@ class PlanningService
             );
         });
 
-        $this->cache->forgetIndex($userId);
+        return $this->forgetIndexAfterCommit($userId);
     }
 
     /**
@@ -136,5 +137,22 @@ class PlanningService
             'commitments' => $planning->get('commitments_values') ?? [],
             'others' => $planning->get('others_values') ?? [],
         ];
+    }
+
+    /**
+     * Keep a committed database mutation authoritative when cache invalidation
+     * is temporarily unavailable. The entry expires after five minutes.
+     */
+    private function forgetIndexAfterCommit(int $userId): bool
+    {
+        try {
+            $this->cache->forgetIndex($userId);
+        } catch (Throwable $exception) {
+            report($exception);
+
+            return false;
+        }
+
+        return true;
     }
 }

--- a/docs/design/planning-summary.md
+++ b/docs/design/planning-summary.md
@@ -21,14 +21,15 @@ The initial summary flow provides period context, remaining planned balance, the
 
 ## Financial meaning boundary
 
-### Current v2.1.4 money behavior and remaining UI gaps
+### Implemented v2.1.4 money and presentation behavior
 
 - The server supplies exact decimal-string income, saving rate, sections, and canonical totals to every projection.
 - `Planning::spending` reads canonical commitments-plus-others spending.
-- Dashboard uses the first returned plan without a user-visible period-selection contract.
+- Dashboard explicitly labels the first server-returned record as the selected/latest available plan; there is no interactive period selector in v2.1.4.
 - The create page uses one BigInt/sen preview helper, excludes submitted totals, and persists server-authoritative values.
+- Dashboard, Planning detail, and Expenses projection share the same exact-value summary, accessible chart alternatives, unavailable/legacy states, and directional target/over-allocation language.
 
-The #63 values and formulas are authoritative. The remaining selection and presentation behaviors are current-state evidence for the UI work, not additional financial rules.
+The #63 values and formulas remain authoritative. The shared presentation layer computes only display ratios, differences, and visual magnitudes from that payload; it does not add financial rules.
 
 ### Authoritative values available to runtime implementation
 
@@ -250,7 +251,7 @@ Names the period, says the record is removed from Planning and its projections, 
 | --- | --- |
 | No plans | Explain monthly planning and offer `Create a plan`; show no zero-filled charts. |
 | Requested plan missing | Standard not-found behavior with route back to Planning; never expose another owner’s existence/data. |
-| Loading | Labelled skeletons reserve hero/cards/chart panels; no fake numbers. |
+| Loading | Current Inertia initial/full visits use the global progress indicator and do not mount the page before authoritative props arrive, so no fake figures are rendered. Labelled skeletons are required if later asynchronous panels render independently. |
 | Partial/legacy data | Show available exact values; mark target/comparison unavailable; do not infer missing values. |
 | Zero allocations | Income remains visible; remaining equals authoritative result; composition chart becomes a purposeful empty state. |
 | Negative remaining | For legacy/migration data or a pre-submit validation preview only, hero and income/allocated panel state exact over-allocation with text/icon/danger role; #63 rejects this as a new persisted target plan. |

--- a/docs/design/planning-summary.md
+++ b/docs/design/planning-summary.md
@@ -2,6 +2,8 @@
 
 This is the approved implementation target for issue #44. It applies the financial UI system in [`ui-system.md`](ui-system.md) to Dashboard, Planning detail, and Expenses detail without changing financial meaning or pretending that planned allocations are transactions.
 
+Issue #124 implements this target in v2.1.4 with shared exact-value summary, chart-panel, allocation-section, planned-trend, and delete-dialog components. Presentation ratios and deltas use one tested BigInt/sen boundary; page components consume the canonical #63 payload and do not redefine financial formulas.
+
 ## Product questions and hierarchy
 
 The summary must answer these questions in order:

--- a/docs/operations/planning-cache.md
+++ b/docs/operations/planning-cache.md
@@ -116,7 +116,7 @@ Check ownership and permissions for `storage/framework/cache/data` against the a
 
 Confirm the selected Redis cache connection and deployment network before retrying application writes. If the approved recovery is to return to the file store, change `CACHE_DRIVER`, refresh Laravel's configuration, and verify a synthetic key before restoring normal traffic.
 
-Cache invalidation runs after the owning database transaction. A cache exception can therefore reach the user after the database write committed. Verify PostgreSQL before retrying a create or delete operation.
+Cache invalidation runs after the owning database transaction. The service reports an invalidation exception without changing the committed database result. A delete redirects to the Planning index with a polite warning that lists may remain stale for the five-minute cache lifetime; it never invites the user to retry a deletion that already committed. Create follows the same database-authoritative boundary and redirects normally. Verify PostgreSQL and the affected cache store before taking further action.
 
 ### A cached value cannot be decoded
 
@@ -137,7 +137,7 @@ Do not run a global cache flush as part of routine rollback. Once the applicatio
 
 ## Validation reference
 
-`tests/Feature/Planning/PlanningCacheTest.php` covers cache hits, per-user isolation, empty results, five-minute expiry, Planning create/delete invalidation, unaffected users, account delete/restore invalidation, and rollback behavior with Laravel's array store.
+`tests/Feature/Planning/PlanningCacheTest.php` and `tests/Feature/Planning/PlanningAuthorizationTest.php` cover cache hits, per-user isolation, empty results, five-minute expiry, Planning create/delete invalidation, committed deletion with failed invalidation, unaffected users, account delete/restore invalidation, and rollback behavior with Laravel's array store.
 
 The operational contract belongs to:
 

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -29,6 +29,10 @@ body {
     --app-warning: #8A4B00;
     --app-warning-foreground: #FFFFFF;
     --app-focus: #285A48;
+    --chart-savings: #285A48;
+    --chart-commitments: #408A71;
+    --chart-others: #83BDA8;
+    --chart-remaining: #B0E4CC;
 }
 
 .dark {
@@ -50,6 +54,10 @@ body {
     --app-warning: #FFD18B;
     --app-warning-foreground: #091413;
     --app-focus: #B0E4CC;
+    --chart-savings: #B0E4CC;
+    --chart-commitments: #65A990;
+    --chart-others: #408A71;
+    --chart-remaining: #285A48;
 }
 
 *:focus-visible {
@@ -98,6 +106,51 @@ body {
     .ui-financial-number { font-variant-numeric: tabular-nums lining-nums; letter-spacing: -.025em; }
     .state-warning { border-color: var(--app-warning); }
     .state-danger { border-color: var(--app-danger); }
+    .button-primary, .button-secondary, .button-danger { display: inline-flex; min-height: 2.75rem; align-items: center; justify-content: center; border-radius: .7rem; padding: .65rem 1rem; font-size: .875rem; font-weight: 700; }
+    .button-primary { background: var(--app-brand-strong); color: var(--app-brand-foreground); }
+    .button-primary:hover { background: var(--app-brand-hover); }
+    .button-secondary { border: 1px solid var(--app-border-strong); background: var(--app-surface); color: var(--app-text-primary); }
+    .button-secondary:hover { background: var(--app-surface-raised); }
+    .button-danger { background: var(--app-danger); color: var(--app-danger-foreground); }
+    .button-primary:disabled, .button-secondary:disabled, .button-danger:disabled { cursor: not-allowed; opacity: .6; }
+    .financial-hero { border-left: .35rem solid var(--app-brand-strong); }
+    .metric-grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(min(100%, 13rem), 1fr)); }
+    .metric-rollup { background: var(--app-surface-raised); }
+    .chart-grid, .allocation-grid { display: grid; gap: 1.5rem; }
+    .financial-chart-panel { min-width: 0; }
+    .financial-table { width: 100%; min-width: 30rem; border-collapse: collapse; font-size: .82rem; }
+    .financial-table th, .financial-table td { border-bottom: 1px solid var(--app-border-quiet); padding: .65rem .5rem; text-align: left; vertical-align: top; }
+    .financial-table thead th { color: var(--app-text-secondary); font-size: .72rem; text-transform: uppercase; letter-spacing: .04em; }
+    .financial-table .is-selected th { box-shadow: inset 3px 0 var(--app-brand-strong); }
+    .chart-empty, .chart-fallback { border: 1px dashed var(--app-border-strong); border-radius: .75rem; padding: 1.25rem; color: var(--app-text-secondary); text-align: center; }
+    .allocation-bar, .income-bar, .target-track { display: flex; width: 100%; height: 1rem; overflow: hidden; border-radius: 999px; background: var(--app-surface-raised); }
+    .allocation-bar span, .income-bar span, .target-track span { min-width: 0; }
+    .chart-savings, .target-track span { background: var(--chart-savings); }
+    .chart-commitments, .chart-allocated { background: var(--chart-commitments); }
+    .chart-others { background: repeating-linear-gradient(135deg, var(--chart-others) 0 7px, var(--app-surface) 7px 9px); }
+    .chart-remaining { background: var(--chart-remaining); }
+    .magnitude-track { height: .4rem; overflow: hidden; border-radius: 999px; background: var(--app-surface-raised); }
+    .magnitude-track span { display: block; height: 100%; border-radius: inherit; background: var(--app-brand-mid); }
+    .trend-bars { display: flex; min-height: 13rem; align-items: end; justify-content: space-around; gap: 1rem; border-bottom: 1px solid var(--app-border-strong); }
+    .trend-bars > div { display: flex; min-width: 0; flex: 1; flex-direction: column; align-items: center; gap: .5rem; color: var(--app-text-secondary); font-size: .7rem; text-align: center; }
+    .trend-bars > .is-selected { color: var(--app-text-primary); font-weight: 700; }
+    .trend-series { display: flex; width: min(100%, 4.5rem); height: 10rem; align-items: end; justify-content: center; gap: .2rem; }
+    .trend-series span { width: 25%; min-height: 2px; border-radius: .25rem .25rem 0 0; }
+    .trend-income { background: var(--chart-savings); }
+    .trend-allocated { background: var(--chart-commitments); }
+    .trend-remaining { background: var(--chart-remaining); }
+    .dialog-layer { position: fixed; z-index: 80; inset: 0; display: grid; place-items: center; padding: 1rem; }
+    .dialog-backdrop { position: absolute; inset: 0; width: 100%; background: rgb(9 20 19 / 68%); }
+    .delete-dialog { position: relative; width: min(100%, 30rem); border: 1px solid var(--app-border-quiet); border-radius: 1rem; background: var(--app-surface); padding: 1.5rem; box-shadow: 0 24px 60px rgb(9 20 19 / 35%); color: var(--app-text-primary); }
+}
+
+@media (min-width: 768px) {
+    .allocation-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+
+@media (min-width: 1024px) {
+    .chart-grid { grid-template-columns: minmax(0, 5fr) minmax(0, 7fr); }
+    .allocation-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -102,6 +102,7 @@ body {
     .app-flash-stack { position: fixed; z-index: 90; top: 1rem; right: 1rem; display: grid; width: min(26rem, calc(100vw - 2rem)); gap: .75rem; }
     .app-flash-message { border: 1px solid var(--app-border-strong); border-radius: .75rem; background: var(--app-surface); padding: .85rem 1rem; box-shadow: 0 12px 32px rgb(9 20 19 / 20%); color: var(--app-text-primary); font-size: .875rem; font-weight: 600; }
     .app-flash-success { border-left: .35rem solid var(--app-brand-strong); }
+    .app-flash-warning { border-left: .35rem solid var(--app-warning); }
     .app-flash-error { border-left: .35rem solid var(--app-danger); }
     .text-primary { color: var(--app-text-primary); }
     .text-secondary { color: var(--app-text-secondary); }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -99,6 +99,10 @@ body {
     .app-account-popover.inline-end { right: 0; }
     .app-skip-link { position: fixed; z-index: 100; left: 1rem; top: 1rem; transform: translateY(-160%); border-radius: .5rem; background: var(--app-brand-strong); color: var(--app-brand-foreground); padding: .65rem .9rem; font-weight: 700; }
     .app-skip-link:focus { transform: translateY(0); }
+    .app-flash-stack { position: fixed; z-index: 90; top: 1rem; right: 1rem; display: grid; width: min(26rem, calc(100vw - 2rem)); gap: .75rem; }
+    .app-flash-message { border: 1px solid var(--app-border-strong); border-radius: .75rem; background: var(--app-surface); padding: .85rem 1rem; box-shadow: 0 12px 32px rgb(9 20 19 / 20%); color: var(--app-text-primary); font-size: .875rem; font-weight: 600; }
+    .app-flash-success { border-left: .35rem solid var(--app-brand-strong); }
+    .app-flash-error { border-left: .35rem solid var(--app-danger); }
     .text-primary { color: var(--app-text-primary); }
     .text-secondary { color: var(--app-text-secondary); }
     .ui-surface { border: 1px solid var(--app-border-quiet); border-radius: 1rem; background: var(--app-surface); color: var(--app-text-primary); }
@@ -129,6 +133,8 @@ body {
     .chart-commitments, .chart-allocated { background: var(--chart-commitments); }
     .chart-others { background: repeating-linear-gradient(135deg, var(--chart-others) 0 7px, var(--app-surface) 7px 9px); }
     .chart-remaining { background: var(--chart-remaining); }
+    .income-bar.is-over-allocated { border: 2px solid var(--app-danger); }
+    .over-allocation-marker { display: inline-block; width: .65rem; height: 1.4rem; margin-top: .5rem; border-radius: 999px; background: var(--app-danger); }
     .magnitude-track { height: .4rem; overflow: hidden; border-radius: 999px; background: var(--app-surface-raised); }
     .magnitude-track span { display: block; height: 100%; border-radius: inherit; background: var(--app-brand-mid); }
     .trend-bars { display: flex; min-height: 13rem; align-items: end; justify-content: space-around; gap: 1rem; border-bottom: 1px solid var(--app-border-strong); }
@@ -139,6 +145,7 @@ body {
     .trend-income { background: var(--chart-savings); }
     .trend-allocated { background: var(--chart-commitments); }
     .trend-remaining { background: var(--chart-remaining); }
+    .trend-over-allocation { background: var(--app-danger); }
     .dialog-layer { position: fixed; z-index: 80; inset: 0; display: grid; place-items: center; padding: 1rem; }
     .dialog-backdrop { position: absolute; inset: 0; width: 100%; background: rgb(9 20 19 / 68%); }
     .delete-dialog { position: relative; width: min(100%, 30rem); border: 1px solid var(--app-border-quiet); border-radius: 1rem; background: var(--app-surface); padding: 1.5rem; box-shadow: 0 24px 60px rgb(9 20 19 / 35%); color: var(--app-text-primary); }

--- a/resources/js/Components/Financial/DeletePlanDialog.tsx
+++ b/resources/js/Components/Financial/DeletePlanDialog.tsx
@@ -42,6 +42,10 @@ export default function DeletePlanDialog({ planningId, planningName }: { plannin
         setPending(true);
         setError(null);
         router.delete(`/planning/${planningId}`, {
+            onSuccess: (page) => {
+                const flash = page.props.flash as { error?: string | null } | undefined;
+                if (flash?.error) setError(flash.error);
+            },
             onError: () => setError('The plan could not be deleted. Try again.'),
             onFinish: () => setPending(false),
         });

--- a/resources/js/Components/Financial/DeletePlanDialog.tsx
+++ b/resources/js/Components/Financial/DeletePlanDialog.tsx
@@ -58,7 +58,7 @@ export default function DeletePlanDialog({ planningId, planningName }: { plannin
                 <h2 id="delete-plan-title" className="text-xl font-bold">Delete {planningName} plan?</h2>
                 <p id="delete-plan-description" className="mt-3 text-sm text-secondary">This removes the monthly plan from Planning and all of its projections. This action cannot be undone.</p>
                 {pending && <p role="status" className="mt-3 text-sm text-secondary">Deleting {planningName} plan…</p>}
-                {error && <p role="alert" className="mt-3 text-sm state-danger">{error}</p>}
+                {error && <p className="mt-3 text-sm state-danger">{error}</p>}
                 <div className="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end"><button ref={cancel} type="button" className="button-secondary" onClick={close} disabled={pending}>Keep plan</button><button ref={confirm} type="button" className="button-danger" onClick={confirmDelete} disabled={pending}>{pending ? 'Deleting plan…' : 'Delete plan permanently'}</button></div>
             </div>
         </div>}

--- a/resources/js/Components/Financial/DeletePlanDialog.tsx
+++ b/resources/js/Components/Financial/DeletePlanDialog.tsx
@@ -1,0 +1,62 @@
+import { KeyboardEvent, useEffect, useRef, useState } from 'react';
+import { router } from '@inertiajs/react';
+
+export default function DeletePlanDialog({ planningId, planningName }: { planningId: string; planningName: string }) {
+    const [open, setOpen] = useState(false);
+    const [pending, setPending] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const trigger = useRef<HTMLButtonElement>(null);
+    const dialog = useRef<HTMLDivElement>(null);
+    const cancel = useRef<HTMLButtonElement>(null);
+    const confirm = useRef<HTMLButtonElement>(null);
+
+    const close = () => {
+        if (pending) return;
+        setOpen(false);
+        setError(null);
+        trigger.current?.focus();
+    };
+
+    useEffect(() => {
+        if (!open) return;
+        cancel.current?.focus();
+        const onEscape = (event: globalThis.KeyboardEvent) => { if (event.key === 'Escape') close(); };
+        document.addEventListener('keydown', onEscape);
+        return () => document.removeEventListener('keydown', onEscape);
+    }, [open, pending]);
+
+    useEffect(() => {
+        if (error && !pending) confirm.current?.focus();
+    }, [error, pending]);
+
+    const trapFocus = (event: KeyboardEvent<HTMLDivElement>) => {
+        if (event.key !== 'Tab' || !dialog.current) return;
+        const controls = [...dialog.current.querySelectorAll<HTMLElement>('button:not([disabled])')];
+        const first = controls[0];
+        const last = controls[controls.length - 1];
+        if (event.shiftKey && document.activeElement === first) { event.preventDefault(); last?.focus(); }
+        else if (!event.shiftKey && document.activeElement === last) { event.preventDefault(); first?.focus(); }
+    };
+
+    const confirmDelete = () => {
+        setPending(true);
+        setError(null);
+        router.delete(`/planning/${planningId}`, {
+            onError: () => setError('The plan could not be deleted. Try again.'),
+            onFinish: () => setPending(false),
+        });
+    };
+
+    return <>
+        <button ref={trigger} type="button" className="button-danger" onClick={() => setOpen(true)}>Delete plan</button>
+        {open && <div className="dialog-layer"><button type="button" className="dialog-backdrop" aria-label="Close delete dialog" onClick={close} disabled={pending} />
+            <div ref={dialog} role="dialog" aria-modal="true" aria-labelledby="delete-plan-title" aria-describedby="delete-plan-description" aria-busy={pending} onKeyDown={trapFocus} className="delete-dialog">
+                <h2 id="delete-plan-title" className="text-xl font-bold">Delete {planningName} plan?</h2>
+                <p id="delete-plan-description" className="mt-3 text-sm text-secondary">This removes the monthly plan from Planning and all of its projections. This action cannot be undone.</p>
+                {pending && <p role="status" className="mt-3 text-sm text-secondary">Deleting {planningName} plan…</p>}
+                {error && <p role="alert" className="mt-3 text-sm state-danger">{error}</p>}
+                <div className="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end"><button ref={cancel} type="button" className="button-secondary" onClick={close} disabled={pending}>Keep plan</button><button ref={confirm} type="button" className="button-danger" onClick={confirmDelete} disabled={pending}>{pending ? 'Deleting plan…' : 'Delete plan permanently'}</button></div>
+            </div>
+        </div>}
+    </>;
+}

--- a/resources/js/Components/Financial/FinancialChartPanel.tsx
+++ b/resources/js/Components/Financial/FinancialChartPanel.tsx
@@ -1,0 +1,10 @@
+import { PropsWithChildren, ReactNode } from 'react';
+import Surface from '@/Components/UI/Surface';
+
+export default function FinancialChartPanel({ title, description, visual, children }: PropsWithChildren<{ title: string; description: string; visual?: ReactNode }>) {
+    return <Surface className="financial-chart-panel p-5">
+        <div className="mb-5"><h2 className="text-lg font-bold">{title}</h2><p className="mt-1 text-sm text-secondary">{description}</p></div>
+        {visual ?? <p role="status" className="chart-fallback">Visual unavailable. Exact values remain below.</p>}
+        <div className="mt-5 overflow-x-auto">{children}</div>
+    </Surface>;
+}

--- a/resources/js/Components/Financial/FinancialChartPanel.tsx
+++ b/resources/js/Components/Financial/FinancialChartPanel.tsx
@@ -4,7 +4,7 @@ import Surface from '@/Components/UI/Surface';
 export default function FinancialChartPanel({ title, description, visual, children }: PropsWithChildren<{ title: string; description: string; visual?: ReactNode }>) {
     return <Surface className="financial-chart-panel p-5">
         <div className="mb-5"><h2 className="text-lg font-bold">{title}</h2><p className="mt-1 text-sm text-secondary">{description}</p></div>
-        {visual ?? <p role="status" className="chart-fallback">Visual unavailable. Exact values remain below.</p>}
+        {visual ?? <p className="chart-fallback">Visual unavailable. Exact values remain below.</p>}
         <div className="mt-5 overflow-x-auto">{children}</div>
     </Surface>;
 }

--- a/resources/js/Components/Financial/PlanningSummary.tsx
+++ b/resources/js/Components/Financial/PlanningSummary.tsx
@@ -7,8 +7,9 @@ import { magnitudeWidth, moneyDifference, presentationRatio, signedMoney } from 
 import FinancialChartPanel from './FinancialChartPanel';
 
 const percentage = (value: string, total: string) => presentationRatio(value, total).label ?? 'Percentage unavailable';
+const availableMoney = (value: string): string | null => signedMoney(value) === null ? null : value;
 
-function ExactTable({ label, rows }: { label: string; rows: Array<{ label: string; value: string; percentage?: string }> }) {
+function ExactTable({ label, rows }: { label: string; rows: Array<{ label: string; value: string | null; percentage?: string }> }) {
     return <table aria-label={label} className="financial-table">
         <thead><tr><th scope="col">Figure</th><th scope="col">Exact value</th><th scope="col">Percentage</th></tr></thead>
         <tbody>{rows.map((row) => <tr key={row.label}><th scope="row">{row.label}</th><td><FinancialNumber value={row.value} /></td><td>{row.percentage ?? 'Not applicable'}</td></tr>)}</tbody>
@@ -21,48 +22,67 @@ function AllocationComposition({ planning }: { planning: Planning }) {
         { label: 'Commitments', value: planning.totals.commitments, className: 'chart-commitments' },
         { label: 'Other allocations', value: planning.totals.others, className: 'chart-others' },
     ];
-    const empty = signedMoney(planning.totals.allocated) === 0n;
-    const visual = empty
-        ? <p role="status" className="chart-empty">No allocations added</p>
+    const unavailable = signedMoney(planning.totals.allocated) === null || rows.some((row) => signedMoney(row.value) === null);
+    const empty = !unavailable && signedMoney(planning.totals.allocated) === 0n;
+    const visual = unavailable
+        ? <p className="chart-empty">Allocation comparison unavailable.</p>
+        : empty
+        ? <p className="chart-empty">No allocations added</p>
         : <div className="allocation-bar" aria-hidden="true">{rows.map((row) => <span key={row.label} className={row.className} style={{ width: `${presentationRatio(row.value, planning.totals.allocated).width}%` }} />)}</div>;
 
     return <FinancialChartPanel title="Allocation composition" description="Savings, commitments, and other allocations in a fixed category order." visual={visual}>
-        <ExactTable label="Allocation composition exact values" rows={rows.map((row) => ({ ...row, percentage: percentage(row.value, planning.totals.allocated) }))} />
+        <ExactTable label="Allocation composition exact values" rows={rows.map((row) => ({ ...row, value: availableMoney(row.value), percentage: percentage(row.value, planning.totals.allocated) }))} />
     </FinancialChartPanel>;
 }
 
 function IncomeAllocation({ planning }: { planning: Planning }) {
+    const incomeValue = signedMoney(planning.salary);
+    const allocatedValue = signedMoney(planning.totals.allocated);
+    const balanceValue = signedMoney(planning.totals.balance);
+    const unavailable = incomeValue === null || allocatedValue === null || balanceValue === null;
     const allocated = presentationRatio(planning.totals.allocated, planning.salary);
     const remaining = presentationRatio(planning.totals.balance, planning.salary);
-    const zeroIncome = signedMoney(planning.salary) === 0n;
-    const negativeBalance = (signedMoney(planning.totals.balance) ?? 0n) < 0n;
-    const visual = zeroIncome
-        ? <p role="status" className="chart-empty">Income comparison unavailable because monthly income is zero.</p>
-        : <div className="income-bar" aria-hidden="true"><span className="chart-allocated" style={{ width: `${allocated.width}%` }} /><span className="chart-remaining" style={{ width: `${remaining.width}%` }} /></div>;
+    const zeroIncome = incomeValue === 0n;
+    const negativeBalance = balanceValue !== null && balanceValue < 0n;
+    const overage = negativeBalance ? planning.totals.balance.replace('-', '') : null;
+    const visual = unavailable
+        ? <p className="chart-empty">Income comparison unavailable.</p>
+        : zeroIncome
+        ? <p className="chart-empty">Income comparison unavailable because monthly income is zero.</p>
+        : <div>{/* Exact text remains visible because the bar itself is decorative. */}<div className={`income-bar ${negativeBalance ? 'is-over-allocated' : ''}`} aria-hidden="true"><span className="chart-allocated" style={{ width: `${allocated.width}%` }} />{!negativeBalance && <span className="chart-remaining" style={{ width: `${remaining.width}%` }} />}</div>{negativeBalance && <><span className="over-allocation-marker" aria-hidden="true" /><p className="mt-2 text-sm font-semibold">Over allocated by {formatMYR(overage)}</p></>}</div>;
 
-    return <FinancialChartPanel title="Income and allocation" description={negativeBalance ? `Over allocated by ${formatMYR(planning.totals.balance.replace('-', ''))}.` : 'How the total planned allocation and remaining balance compare with monthly income.'} visual={visual}>
+    return <FinancialChartPanel title="Income and allocation" description={unavailable ? 'Income comparison unavailable.' : negativeBalance ? `Over allocated by ${formatMYR(overage)}.` : 'How the total planned allocation and remaining balance compare with monthly income.'} visual={visual}>
         <ExactTable label="Income and allocation exact values" rows={[
-            { label: 'Monthly income', value: planning.salary },
-            { label: 'Total planned allocation', value: planning.totals.allocated, percentage: allocated.label ?? 'Percentage unavailable' },
-            { label: negativeBalance ? 'Over allocation' : 'Remaining planned balance', value: negativeBalance ? planning.totals.balance.replace('-', '') : planning.totals.balance, percentage: remaining.label ?? 'Percentage unavailable' },
+            { label: 'Monthly income', value: availableMoney(planning.salary) },
+            { label: 'Total planned allocation', value: availableMoney(planning.totals.allocated), percentage: allocated.label ?? 'Percentage unavailable' },
+            { label: negativeBalance ? 'Over allocation' : 'Remaining planned balance', value: availableMoney(negativeBalance ? overage! : planning.totals.balance), percentage: remaining.label ?? 'Percentage unavailable' },
         ]} />
     </FinancialChartPanel>;
 }
 
 function SavingsTarget({ planning }: { planning: Planning }) {
+    const savingsValue = signedMoney(planning.totals.savings);
+    const targetValue = signedMoney(planning.totals.target_savings);
+    const unavailable = savingsValue === null || targetValue === null;
     const progress = presentationRatio(planning.totals.savings, planning.totals.target_savings);
-    const zeroTarget = signedMoney(planning.totals.target_savings) === 0n;
-    const difference = moneyDifference(planning.totals.savings, planning.totals.target_savings) ?? '0.00';
-    const above = difference.startsWith('-') === false && difference !== '0.00';
-    const visual = zeroTarget
-        ? <p role="status" className="chart-empty">{signedMoney(planning.totals.savings) === 0n ? 'No savings target set' : 'Target is zero; percentage unavailable'}</p>
-        : <div><div className="target-track" aria-hidden="true"><span style={{ width: `${progress.width}%` }} /></div>{above && <p className="mt-2 text-sm font-semibold">Above savings target by {formatMYR(difference)}</p>}</div>;
+    const zeroTarget = targetValue === 0n;
+    const difference = moneyDifference(planning.totals.savings, planning.totals.target_savings);
+    const above = difference !== null && difference.startsWith('-') === false && difference !== '0.00';
+    const below = difference !== null && difference.startsWith('-');
+    const absoluteDifference = difference?.replace('-', '') ?? null;
+    const differenceLabel = unavailable ? 'Comparison unavailable' : above ? 'Above target by' : below ? 'Below target by' : 'Target difference';
+    const directionText = above ? 'Above savings target by' : below ? 'Below savings target by' : null;
+    const visual = unavailable
+        ? <p className="chart-empty">Savings target comparison unavailable.</p>
+        : zeroTarget
+        ? <p className="chart-empty">{signedMoney(planning.totals.savings) === 0n ? 'No savings target set' : 'Target is zero; percentage unavailable'}</p>
+        : <div><div className="target-track" aria-hidden="true"><span style={{ width: `${progress.width}%` }} /></div>{directionText && <p className="mt-2 text-sm font-semibold">{directionText} {formatMYR(absoluteDifference)}</p>}</div>;
 
     return <FinancialChartPanel title="Savings target" description="Savings allocation compared with the advisory target." visual={visual}>
         <ExactTable label="Savings target exact values" rows={[
-            { label: 'Savings target', value: planning.totals.target_savings },
-            { label: 'Savings allocation', value: planning.totals.savings, percentage: progress.label ?? 'Percentage unavailable' },
-            { label: above ? 'Above target by' : 'Target difference', value: difference.replace('-', '') },
+            { label: 'Savings target', value: availableMoney(planning.totals.target_savings) },
+            { label: 'Savings allocation', value: availableMoney(planning.totals.savings), percentage: progress.label ?? 'Percentage unavailable' },
+            { label: differenceLabel, value: absoluteDifference },
         ]} />
     </FinancialChartPanel>;
 }
@@ -84,9 +104,14 @@ export function AllocationSection({ title, total, items = [] }: { title: string;
 
 export default function PlanningSummary({ planning, showSections = true }: { planning: Planning; showSections?: boolean }) {
     const targetProgress = percentage(planning.totals.savings, planning.totals.target_savings);
+    const balance = signedMoney(planning.totals.balance);
+    const overAllocated = balance !== null && balance < 0n;
+    const heroContext = overAllocated
+        ? `Over allocated by ${formatMYR(planning.totals.balance.replace('-', ''))}`
+        : balance === null ? `${planning.name} balance unavailable` : `${planning.name} monthly plan`;
 
     return <div className="space-y-6">
-        <MetricCard hero label="Remaining planned balance" value={planning.totals.balance} context={`${planning.name} monthly plan`} className="financial-hero" />
+        <MetricCard hero label="Remaining planned balance" value={planning.totals.balance} context={heroContext} tone={overAllocated ? 'danger' : 'neutral'} className="financial-hero" />
         <div className="metric-grid">
             <MetricCard label="Monthly income" value={planning.salary} context={planning.name} />
             <MetricCard label="Savings allocation" value={planning.totals.savings} context={`Target ${formatMYR(planning.totals.target_savings)} · ${targetProgress}`} />

--- a/resources/js/Components/Financial/PlanningSummary.tsx
+++ b/resources/js/Components/Financial/PlanningSummary.tsx
@@ -1,0 +1,104 @@
+import FinancialNumber from '@/Components/UI/FinancialNumber';
+import MetricCard from '@/Components/UI/MetricCard';
+import Surface from '@/Components/UI/Surface';
+import { Planning, SectionItem } from '@/types';
+import { formatMYR, parseMoney } from '@/utils/money';
+import { magnitudeWidth, moneyDifference, presentationRatio, signedMoney } from '@/utils/financialPresentation';
+import FinancialChartPanel from './FinancialChartPanel';
+
+const percentage = (value: string, total: string) => presentationRatio(value, total).label ?? 'Percentage unavailable';
+
+function ExactTable({ label, rows }: { label: string; rows: Array<{ label: string; value: string; percentage?: string }> }) {
+    return <table aria-label={label} className="financial-table">
+        <thead><tr><th scope="col">Figure</th><th scope="col">Exact value</th><th scope="col">Percentage</th></tr></thead>
+        <tbody>{rows.map((row) => <tr key={row.label}><th scope="row">{row.label}</th><td><FinancialNumber value={row.value} /></td><td>{row.percentage ?? 'Not applicable'}</td></tr>)}</tbody>
+    </table>;
+}
+
+function AllocationComposition({ planning }: { planning: Planning }) {
+    const rows = [
+        { label: 'Savings allocation', value: planning.totals.savings, className: 'chart-savings' },
+        { label: 'Commitments', value: planning.totals.commitments, className: 'chart-commitments' },
+        { label: 'Other allocations', value: planning.totals.others, className: 'chart-others' },
+    ];
+    const empty = signedMoney(planning.totals.allocated) === 0n;
+    const visual = empty
+        ? <p role="status" className="chart-empty">No allocations added</p>
+        : <div className="allocation-bar" aria-hidden="true">{rows.map((row) => <span key={row.label} className={row.className} style={{ width: `${presentationRatio(row.value, planning.totals.allocated).width}%` }} />)}</div>;
+
+    return <FinancialChartPanel title="Allocation composition" description="Savings, commitments, and other allocations in a fixed category order." visual={visual}>
+        <ExactTable label="Allocation composition exact values" rows={rows.map((row) => ({ ...row, percentage: percentage(row.value, planning.totals.allocated) }))} />
+    </FinancialChartPanel>;
+}
+
+function IncomeAllocation({ planning }: { planning: Planning }) {
+    const allocated = presentationRatio(planning.totals.allocated, planning.salary);
+    const remaining = presentationRatio(planning.totals.balance, planning.salary);
+    const zeroIncome = signedMoney(planning.salary) === 0n;
+    const negativeBalance = (signedMoney(planning.totals.balance) ?? 0n) < 0n;
+    const visual = zeroIncome
+        ? <p role="status" className="chart-empty">Income comparison unavailable because monthly income is zero.</p>
+        : <div className="income-bar" aria-hidden="true"><span className="chart-allocated" style={{ width: `${allocated.width}%` }} /><span className="chart-remaining" style={{ width: `${remaining.width}%` }} /></div>;
+
+    return <FinancialChartPanel title="Income and allocation" description={negativeBalance ? `Over allocated by ${formatMYR(planning.totals.balance.replace('-', ''))}.` : 'How the total planned allocation and remaining balance compare with monthly income.'} visual={visual}>
+        <ExactTable label="Income and allocation exact values" rows={[
+            { label: 'Monthly income', value: planning.salary },
+            { label: 'Total planned allocation', value: planning.totals.allocated, percentage: allocated.label ?? 'Percentage unavailable' },
+            { label: negativeBalance ? 'Over allocation' : 'Remaining planned balance', value: negativeBalance ? planning.totals.balance.replace('-', '') : planning.totals.balance, percentage: remaining.label ?? 'Percentage unavailable' },
+        ]} />
+    </FinancialChartPanel>;
+}
+
+function SavingsTarget({ planning }: { planning: Planning }) {
+    const progress = presentationRatio(planning.totals.savings, planning.totals.target_savings);
+    const zeroTarget = signedMoney(planning.totals.target_savings) === 0n;
+    const difference = moneyDifference(planning.totals.savings, planning.totals.target_savings) ?? '0.00';
+    const above = difference.startsWith('-') === false && difference !== '0.00';
+    const visual = zeroTarget
+        ? <p role="status" className="chart-empty">{signedMoney(planning.totals.savings) === 0n ? 'No savings target set' : 'Target is zero; percentage unavailable'}</p>
+        : <div><div className="target-track" aria-hidden="true"><span style={{ width: `${progress.width}%` }} /></div>{above && <p className="mt-2 text-sm font-semibold">Above savings target by {formatMYR(difference)}</p>}</div>;
+
+    return <FinancialChartPanel title="Savings target" description="Savings allocation compared with the advisory target." visual={visual}>
+        <ExactTable label="Savings target exact values" rows={[
+            { label: 'Savings target', value: planning.totals.target_savings },
+            { label: 'Savings allocation', value: planning.totals.savings, percentage: progress.label ?? 'Percentage unavailable' },
+            { label: above ? 'Above target by' : 'Target difference', value: difference.replace('-', '') },
+        ]} />
+    </FinancialChartPanel>;
+}
+
+export function AllocationSection({ title, total, items = [] }: { title: string; total: string; items?: SectionItem[] }) {
+    const maximum = items.reduce((max, item) => {
+        const amount = parseMoney(item.amount) ?? 0n;
+        return amount > max ? amount : max;
+    }, 0n);
+
+    return <Surface className="allocation-section p-5">
+        <div className="flex items-start justify-between gap-4"><div><h2 className="text-lg font-bold">{title}</h2><p className="mt-1 text-sm text-secondary">{items.length} {items.length === 1 ? 'item' : 'items'}</p></div><FinancialNumber value={total} className="font-bold" /></div>
+        {items.length === 0 ? <p className="mt-5 text-sm text-secondary">No items added.</p> : <ul className="mt-5 space-y-4">{items.map((item, index) => <li key={`${item.item}-${index}`}>
+            <div className="flex items-start justify-between gap-4 text-sm"><span className="min-w-0 break-words">{item.item}</span><FinancialNumber value={item.amount} className="shrink-0 font-semibold" /></div>
+            <div className="magnitude-track mt-2" aria-hidden="true"><span style={{ width: `${magnitudeWidth(item.amount, maximum)}%` }} /></div>
+        </li>)}</ul>}
+    </Surface>;
+}
+
+export default function PlanningSummary({ planning, showSections = true }: { planning: Planning; showSections?: boolean }) {
+    const targetProgress = percentage(planning.totals.savings, planning.totals.target_savings);
+
+    return <div className="space-y-6">
+        <MetricCard hero label="Remaining planned balance" value={planning.totals.balance} context={`${planning.name} monthly plan`} className="financial-hero" />
+        <div className="metric-grid">
+            <MetricCard label="Monthly income" value={planning.salary} context={planning.name} />
+            <MetricCard label="Savings allocation" value={planning.totals.savings} context={`Target ${formatMYR(planning.totals.target_savings)} · ${targetProgress}`} />
+            <MetricCard label="Commitments" value={planning.totals.commitments} />
+            <MetricCard label="Other allocations" value={planning.totals.others} />
+            <MetricCard label="Total planned allocation" value={planning.totals.allocated} context={`Planned spending ${formatMYR(planning.totals.spending)}`} className="metric-rollup" />
+        </div>
+        <div className="chart-grid"><AllocationComposition planning={planning} /><div className="space-y-6"><IncomeAllocation planning={planning} /><SavingsTarget planning={planning} /></div></div>
+        {showSections && <div className="allocation-grid">
+            <AllocationSection title="Savings allocation" total={planning.totals.savings} items={planning.sections?.savings} />
+            <AllocationSection title="Commitments" total={planning.totals.commitments} items={planning.sections?.commitments} />
+            <AllocationSection title="Other allocations" total={planning.totals.others} items={planning.sections?.others} />
+        </div>}
+    </div>;
+}

--- a/resources/js/Components/Financial/PlanningTrend.tsx
+++ b/resources/js/Components/Financial/PlanningTrend.tsx
@@ -6,14 +6,23 @@ import FinancialChartPanel from './FinancialChartPanel';
 export default function PlanningTrend({ plannings, selectedId }: { plannings: Planning[]; selectedId: string }) {
     if (plannings.length < 2) return null;
     const ordered = [...plannings].sort((left, right) => (left.year - right.year) || (left.month - right.month));
+    const unavailable = ordered.some((planning) => [planning.salary, planning.totals.allocated, planning.totals.balance].some((value) => signedMoney(value) === null));
     const maximum = ordered.reduce((max, planning) => {
-        const values = [planning.salary, planning.totals.allocated, planning.totals.balance].map((value) => signedMoney(value) ?? 0n);
+        const values = [planning.salary, planning.totals.allocated, planning.totals.balance].map((value) => {
+            const parsed = signedMoney(value) ?? 0n;
+            return parsed < 0n ? -parsed : parsed;
+        });
         return values.reduce((innerMax, value) => value > innerMax ? value : innerMax, max);
     }, 0n);
 
-    const visual = <div className="trend-bars" aria-hidden="true">{ordered.map((planning) => <div key={planning.planning_id} className={planning.planning_id === selectedId ? 'is-selected' : ''}>
-        <div className="trend-series"><span className="trend-income" style={{ height: `${magnitudeWidth(planning.salary, maximum)}%` }} /><span className="trend-allocated" style={{ height: `${magnitudeWidth(planning.totals.allocated, maximum)}%` }} /><span className="trend-remaining" style={{ height: `${magnitudeWidth(planning.totals.balance, maximum)}%` }} /></div><span>{planning.name}</span>
-    </div>)}</div>;
+    const visual = unavailable ? undefined : <div className="trend-bars" aria-hidden="true">{ordered.map((planning) => {
+        const negativeRemaining = (signedMoney(planning.totals.balance) ?? 0n) < 0n;
+        const remainingMagnitude = negativeRemaining ? planning.totals.balance.replace('-', '') : planning.totals.balance;
+
+        return <div key={planning.planning_id} className={planning.planning_id === selectedId ? 'is-selected' : ''}>
+            <div className="trend-series"><span className="trend-income" style={{ height: `${magnitudeWidth(planning.salary, maximum)}%` }} /><span className="trend-allocated" style={{ height: `${magnitudeWidth(planning.totals.allocated, maximum)}%` }} /><span className={negativeRemaining ? 'trend-over-allocation' : 'trend-remaining'} style={{ height: `${magnitudeWidth(remainingMagnitude, maximum)}%` }} /></div><span>{planning.name}</span>
+        </div>;
+    })}</div>;
 
     return <FinancialChartPanel title="Planned trend" description="Monthly income, total planned allocation, and remaining planned balance across available periods." visual={visual}>
         <table aria-label="Planned trend exact values" className="financial-table"><thead><tr><th scope="col">Period</th><th scope="col">Income</th><th scope="col">Allocated</th><th scope="col">Remaining</th></tr></thead><tbody>{ordered.map((planning) => <tr key={planning.planning_id} className={planning.planning_id === selectedId ? 'is-selected' : ''}><th scope="row">{planning.name}{planning.planning_id === selectedId ? ' (selected)' : ''}</th><td><FinancialNumber value={planning.salary} /></td><td><FinancialNumber value={planning.totals.allocated} /></td><td><FinancialNumber value={planning.totals.balance} /></td></tr>)}</tbody></table>

--- a/resources/js/Components/Financial/PlanningTrend.tsx
+++ b/resources/js/Components/Financial/PlanningTrend.tsx
@@ -1,0 +1,21 @@
+import FinancialNumber from '@/Components/UI/FinancialNumber';
+import { Planning } from '@/types';
+import { magnitudeWidth, signedMoney } from '@/utils/financialPresentation';
+import FinancialChartPanel from './FinancialChartPanel';
+
+export default function PlanningTrend({ plannings, selectedId }: { plannings: Planning[]; selectedId: string }) {
+    if (plannings.length < 2) return null;
+    const ordered = [...plannings].sort((left, right) => (left.year - right.year) || (left.month - right.month));
+    const maximum = ordered.reduce((max, planning) => {
+        const values = [planning.salary, planning.totals.allocated, planning.totals.balance].map((value) => signedMoney(value) ?? 0n);
+        return values.reduce((innerMax, value) => value > innerMax ? value : innerMax, max);
+    }, 0n);
+
+    const visual = <div className="trend-bars" aria-hidden="true">{ordered.map((planning) => <div key={planning.planning_id} className={planning.planning_id === selectedId ? 'is-selected' : ''}>
+        <div className="trend-series"><span className="trend-income" style={{ height: `${magnitudeWidth(planning.salary, maximum)}%` }} /><span className="trend-allocated" style={{ height: `${magnitudeWidth(planning.totals.allocated, maximum)}%` }} /><span className="trend-remaining" style={{ height: `${magnitudeWidth(planning.totals.balance, maximum)}%` }} /></div><span>{planning.name}</span>
+    </div>)}</div>;
+
+    return <FinancialChartPanel title="Planned trend" description="Monthly income, total planned allocation, and remaining planned balance across available periods." visual={visual}>
+        <table aria-label="Planned trend exact values" className="financial-table"><thead><tr><th scope="col">Period</th><th scope="col">Income</th><th scope="col">Allocated</th><th scope="col">Remaining</th></tr></thead><tbody>{ordered.map((planning) => <tr key={planning.planning_id} className={planning.planning_id === selectedId ? 'is-selected' : ''}><th scope="row">{planning.name}{planning.planning_id === selectedId ? ' (selected)' : ''}</th><td><FinancialNumber value={planning.salary} /></td><td><FinancialNumber value={planning.totals.allocated} /></td><td><FinancialNumber value={planning.totals.balance} /></td></tr>)}</tbody></table>
+    </FinancialChartPanel>;
+}

--- a/resources/js/Components/UI/FinancialNumber.tsx
+++ b/resources/js/Components/UI/FinancialNumber.tsx
@@ -4,6 +4,7 @@ export default function FinancialNumber({ value, className = '', unavailableLabe
     if (value === null || value === undefined) return <span className={`ui-financial-number ${className}`} aria-label={unavailableLabel}>RM —</span>;
     const negative = value.startsWith('-');
     const formatted = formatMYR(negative ? value.slice(1) : value);
+    if (formatted === 'RM —') return <span className={`ui-financial-number ${className}`} aria-label={unavailableLabel}>{formatted}</span>;
     const display = negative && formatted !== 'RM —' ? `−${formatted}` : formatted;
 
     return <span className={`ui-financial-number ${className}`}>{display}</span>;

--- a/resources/js/Components/UI/MetricCard.tsx
+++ b/resources/js/Components/UI/MetricCard.tsx
@@ -1,10 +1,10 @@
 import FinancialNumber from './FinancialNumber';
 import Surface from './Surface';
 
-export default function MetricCard({ label, value, context, hero = false, className = '' }: { label: string; value?: string | null; context?: string; hero?: boolean; className?: string; }) {
-    return <Surface className={`p-5 ${hero ? 'ui-surface-raised' : ''} ${className}`}>
+export default function MetricCard({ label, value, context, hero = false, className = '', tone = 'neutral' }: { label: string; value?: string | null; context?: string; hero?: boolean; className?: string; tone?: 'neutral' | 'danger'; }) {
+    return <Surface className={`p-5 ${hero ? 'ui-surface-raised' : ''} ${tone === 'danger' ? 'state-danger' : ''} ${className}`}>
         <p className="text-sm font-semibold text-secondary">{label}</p>
         <p className={`${hero ? 'text-3xl sm:text-4xl' : 'text-2xl'} mt-2 font-bold`}><FinancialNumber value={value} /></p>
-        {context && <p className="mt-2 text-sm text-secondary">{context}</p>}
+        {context && <p className="mt-2 flex items-start gap-2 text-sm text-secondary">{tone === 'danger' && <span aria-hidden="true">⚠</span>}<span>{context}</span></p>}
     </Surface>;
 }

--- a/resources/js/Layouts/AppLayout.tsx
+++ b/resources/js/Layouts/AppLayout.tsx
@@ -92,8 +92,9 @@ export default function AppLayout({ user, header, children }: PropsWithChildren<
 
     return <div className="app-shell min-h-screen">
         <a href="#main-content" className="app-skip-link">Skip to main content</a>
-        {(notice || flash?.error) && <div className="app-flash-stack">
+        {(notice || flash?.warning || flash?.error) && <div className="app-flash-stack">
             {notice && <div role="status" aria-live="polite" className="app-flash-message app-flash-success">{notice}</div>}
+            {flash?.warning && <div role="status" aria-live="polite" className="app-flash-message app-flash-warning">{flash.warning}</div>}
             {flash?.error && <div role="alert" aria-live="assertive" className="app-flash-message app-flash-error">{flash.error}</div>}
         </div>}
         <aside data-testid="desktop-sidebar" className="app-sidebar fixed inset-y-0 left-0 z-30 hidden w-64 flex-col lg:flex" aria-label="Application navigation">

--- a/resources/js/Layouts/AppLayout.tsx
+++ b/resources/js/Layouts/AppLayout.tsx
@@ -49,7 +49,7 @@ function AccountControls({ user, locale, common, compact = false }: { user: User
 
 export default function AppLayout({ user, header, children }: PropsWithChildren<AppLayoutProps>) {
     const page = usePage<AppPageProps>();
-    const { locale, translations } = page.props;
+    const { locale, translations, flash } = page.props;
     const common = translations?.common as Record<string, unknown> | undefined;
     const currentPath = page.url.split('?')[0];
     const [drawerOpen, setDrawerOpen] = useState(false);
@@ -61,6 +61,7 @@ export default function AppLayout({ user, header, children }: PropsWithChildren<
         { label: t(common, 'expenses', 'Expenses'), href: route('expenses.index'), match: '/expenses', icon: 'expenses' },
         { label: 'Profile', href: route('profile.edit'), match: '/profile', icon: 'profile' },
     ];
+    const notice = flash?.success ?? flash?.message;
 
     const closeDrawer = (focusMain = false) => {
         setDrawerOpen(false);
@@ -91,6 +92,10 @@ export default function AppLayout({ user, header, children }: PropsWithChildren<
 
     return <div className="app-shell min-h-screen">
         <a href="#main-content" className="app-skip-link">Skip to main content</a>
+        {(notice || flash?.error) && <div className="app-flash-stack">
+            {notice && <div role="status" aria-live="polite" className="app-flash-message app-flash-success">{notice}</div>}
+            {flash?.error && <div role="alert" aria-live="assertive" className="app-flash-message app-flash-error">{flash.error}</div>}
+        </div>}
         <aside data-testid="desktop-sidebar" className="app-sidebar fixed inset-y-0 left-0 z-30 hidden w-64 flex-col lg:flex" aria-label="Application navigation">
             <Link href={route('landing')} className="app-brand"><span className="app-brand-mark" aria-hidden="true">E</span><span>Expenses</span></Link>
             <nav className="mt-8 flex-1 space-y-2"><DestinationLinks destinations={destinations.slice(0, 3)} currentPath={currentPath} /></nav>

--- a/resources/js/Pages/Dashboard/Index.tsx
+++ b/resources/js/Pages/Dashboard/Index.tsx
@@ -1,57 +1,25 @@
-import { Head } from '@inertiajs/react';
+import { Head, Link } from '@inertiajs/react';
+import PlanningSummary from '@/Components/Financial/PlanningSummary';
+import PlanningTrend from '@/Components/Financial/PlanningTrend';
+import PageContainer from '@/Components/UI/PageContainer';
+import StatePanel from '@/Components/UI/StatePanel';
 import AppLayout from '@/Layouts/AppLayout';
 import { PageProps, Planning } from '@/types';
-import { formatMYR } from '@/utils/money';
 
-interface DashboardProps extends PageProps {
-    plannings: Planning[];
-}
+interface DashboardProps extends PageProps { plannings: Planning[]; }
 
 export default function Index({ auth, plannings }: DashboardProps) {
-    return (
-        <AppLayout user={auth.user!} header={<h2 className="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">Dashboard</h2>}>
-            <Head title="Dashboard" />
+    const selected = plannings?.[0];
 
-            <div className="py-12">
-                <div className="max-w-7xl mx-auto sm:px-6 lg:px-8">
-                    <div className="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
-                        <div className="p-6 text-gray-900 dark:text-gray-100">
-                            <h3 className="text-lg font-semibold mb-4">
-                                Welcome back, {auth.user?.name}!
-                            </h3>
-
-                            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-                                <div className="bg-indigo-50 dark:bg-indigo-900/30 rounded-lg p-6">
-                                    <h4 className="text-sm font-medium text-indigo-600 dark:text-indigo-400 uppercase tracking-wide">
-                                        Total Plannings
-                                    </h4>
-                                    <p className="mt-2 text-3xl font-bold text-indigo-900 dark:text-indigo-100">
-                                        {plannings?.length || 0}
-                                    </p>
-                                </div>
-
-                                <div className="bg-green-50 dark:bg-green-900/30 rounded-lg p-6">
-                                    <h4 className="text-sm font-medium text-green-600 dark:text-green-400 uppercase tracking-wide">
-                                        This Month's Budget
-                                    </h4>
-                                    <p className="mt-2 text-3xl font-bold text-green-900 dark:text-green-100">
-                                        {plannings?.[0] ? formatMYR(plannings[0].salary) : 'RM —'}
-                                    </p>
-                                </div>
-
-                                <div className="bg-purple-50 dark:bg-purple-900/30 rounded-lg p-6">
-                                    <h4 className="text-sm font-medium text-purple-600 dark:text-purple-400 uppercase tracking-wide">
-                                        Savings Goal
-                                    </h4>
-                                    <p className="mt-2 text-3xl font-bold text-purple-900 dark:text-purple-100">
-                                        {plannings?.[0] ? formatMYR(plannings[0].totals.target_savings) : 'RM —'}
-                                    </p>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </AppLayout>
-    );
+    return <AppLayout user={auth.user!} header={<h1 className="text-xl font-bold">Dashboard</h1>}>
+        <Head title="Dashboard" />
+        <PageContainer className="py-8 sm:py-10">
+            {!selected ? <StatePanel title="Create your first monthly plan" description="Add income and planned allocations to unlock exact figures and useful comparisons." action={<Link href="/planning/create" className="button-primary">Create a plan</Link>} /> : <div className="space-y-8">
+                <div><p className="text-sm font-semibold text-secondary">Welcome back, {auth.user?.name}</p><h2 className="mt-1 text-2xl font-bold">Selected plan: {selected.name}</h2><p className="mt-2 text-sm text-secondary">The latest available record is selected explicitly; figures below remain planned values.</p></div>
+                <PlanningSummary planning={selected} showSections={false} />
+                <PlanningTrend plannings={plannings} selectedId={selected.planning_id} />
+                <div className="flex flex-wrap gap-3"><Link href={`/planning/${selected.planning_id}`} className="button-primary">Open full plan</Link><Link href="/planning/create" className="button-secondary">Create another plan</Link></div>
+            </div>}
+        </PageContainer>
+    </AppLayout>;
 }

--- a/resources/js/Pages/Expenses/Show.tsx
+++ b/resources/js/Pages/Expenses/Show.tsx
@@ -1,68 +1,18 @@
 import { Head, Link } from '@inertiajs/react';
+import PlanningSummary from '@/Components/Financial/PlanningSummary';
+import PageContainer from '@/Components/UI/PageContainer';
 import AppLayout from '@/Layouts/AppLayout';
 import { PageProps, Planning } from '@/types';
-import { formatMYR } from '@/utils/money';
 
-interface ShowProps extends PageProps {
-    planning: Planning;
-}
+interface ShowProps extends PageProps { planning: Planning; }
 
 export default function Show({ auth, planning }: ShowProps) {
-    const planningName = planning.name;
-
-    return (
-        <AppLayout user={auth.user!} header={<h2 className="font-semibold text-xl text-gray-800 leading-tight">Expenses - {planningName}</h2>}>
-            <Head title={`Expenses - ${planningName}`} />
-
-            <div className="py-12">
-                <div className="max-w-7xl mx-auto sm:px-6 lg:px-8">
-                    <div className="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                        <div className="p-6">
-                            <div className="mb-6">
-                                <h3 className="text-lg font-semibold text-gray-800">
-                                    {planningName}
-                                </h3>
-                            </div>
-
-                            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
-                                <div className="bg-blue-50 rounded-lg p-4">
-                                    <p className="text-sm text-blue-600">Salary</p>
-                                    <p className="text-2xl font-bold text-blue-900">
-                                        {formatMYR(planning.salary)}
-                                    </p>
-                                </div>
-                                <div className="bg-red-50 rounded-lg p-4">
-                                    <p className="text-sm text-red-600">Total Spending</p>
-                                    <p className="text-2xl font-bold text-red-900">
-                                        {formatMYR(planning.totals.spending)}
-                                    </p>
-                                </div>
-                                <div className="bg-green-50 rounded-lg p-4">
-                                    <p className="text-sm text-green-600">Remaining</p>
-                                    <p className="text-2xl font-bold text-green-900">
-                                        {formatMYR(planning.totals.balance)}
-                                    </p>
-                                </div>
-                            </div>
-
-                            <div className="border-t pt-6">
-                                <p className="text-gray-500 text-center py-8">
-                                    No expenses recorded yet for this planning.
-                                </p>
-                            </div>
-
-                            <div className="mt-8">
-                                <Link
-                                    href="/expenses"
-                                    className="text-indigo-600 hover:text-indigo-500"
-                                >
-                                    ← Back to Expenses
-                                </Link>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </AppLayout>
-    );
+    return <AppLayout user={auth.user!} header={<h1 className="text-xl font-bold">Expense projection</h1>}>
+        <Head title={`Expense projection - ${planning.name}`} />
+        <PageContainer className="py-8 sm:py-10">
+            <div className="mb-7"><p className="text-sm font-semibold text-secondary">{planning.name}</p><h2 className="mt-1 text-2xl font-bold">Planned allocation breakdown</h2><p className="mt-2 max-w-3xl text-sm text-secondary">This read-only projection uses the monthly plan. It is not a transaction ledger and does not represent actual bank spending.</p></div>
+            <PlanningSummary planning={planning} />
+            <div className="mt-8 flex flex-wrap gap-3"><Link href={`/planning/${planning.planning_id}`} className="button-primary">Open full plan</Link><Link href="/expenses" className="button-secondary">Back to Expenses</Link></div>
+        </PageContainer>
+    </AppLayout>;
 }

--- a/resources/js/Pages/Planning/Show.tsx
+++ b/resources/js/Pages/Planning/Show.tsx
@@ -1,115 +1,22 @@
-import { Head, Link, router } from '@inertiajs/react';
+import { Head, Link } from '@inertiajs/react';
+import DeletePlanDialog from '@/Components/Financial/DeletePlanDialog';
+import PlanningSummary from '@/Components/Financial/PlanningSummary';
+import PageContainer from '@/Components/UI/PageContainer';
 import AppLayout from '@/Layouts/AppLayout';
-import { PageProps, Planning, SectionItem } from '@/types';
-import { formatMYR } from '@/utils/money';
+import { PageProps, Planning } from '@/types';
 
-interface ShowProps extends PageProps {
-    planning: Planning;
-}
+interface ShowProps extends PageProps { planning: Planning; }
 
 export default function Show({ auth, planning }: ShowProps) {
-    const handleDelete = () => {
-        if (confirm('Are you sure you want to delete this planning?')) {
-            router.delete(`/planning/${planning.planning_id}`);
-        }
-    };
-
-    const renderSection = (title: string, total: string, items?: SectionItem[], colorClass = 'bg-gray-50') => {
-        if (!items || items.length === 0) return null;
-
-        return (
-            <div className={`rounded-lg p-4 ${colorClass}`}>
-                <div className="flex justify-between items-center mb-3">
-                    <h4 className="font-semibold">{title}</h4>
-                    <span className="text-sm font-medium">
-                        {formatMYR(total)}
-                    </span>
-                </div>
-                <div className="space-y-2">
-                    {items.map((item, index) => (
-                        <div key={index} className="flex justify-between text-sm">
-                            <span>{item.item}</span>
-                            <span>{formatMYR(item.amount)}</span>
-                        </div>
-                    ))}
-                </div>
+    return <AppLayout user={auth.user!} header={<h1 className="text-xl font-bold">{planning.name}</h1>}>
+        <Head title={planning.name} />
+        <PageContainer className="py-8 sm:py-10">
+            <div className="mb-7"><p className="text-sm font-semibold text-secondary">Monthly plan</p><h2 className="mt-1 text-2xl font-bold">Financial planning summary</h2><p className="mt-2 text-sm text-secondary">Exact server-authoritative figures for {planning.name}.</p></div>
+            <PlanningSummary planning={planning} />
+            <div className="mt-8 flex flex-col gap-5 border-t pt-6 sm:flex-row sm:items-center sm:justify-between" style={{ borderColor: 'var(--app-border-quiet)' }}>
+                <div className="flex flex-wrap gap-3"><Link href={`/expenses/${planning.planning_id}`} className="button-primary">View expense projection</Link><Link href="/planning" className="button-secondary">Back to Planning</Link></div>
+                <DeletePlanDialog planningId={planning.planning_id} planningName={planning.name} />
             </div>
-        );
-    };
-
-    return (
-        <AppLayout user={auth.user!} header={<h2 className="font-semibold text-xl text-gray-800 leading-tight">{planning.name}</h2>}>
-            <Head title={planning.name} />
-
-            <div className="py-12">
-                <div className="max-w-4xl mx-auto sm:px-6 lg:px-8">
-                    <div className="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                        <div className="p-6">
-                            {/* Actions */}
-                            <div className="mb-6 flex justify-end items-center">
-                                <div className="flex gap-2">
-                                    <Link
-                                        href={`/expenses/${planning.planning_id}`}
-                                        className="bg-green-600 text-white px-4 py-2 rounded-md hover:bg-green-700"
-                                    >
-                                        View Expenses
-                                    </Link>
-                                    <button
-                                        onClick={handleDelete}
-                                        className="bg-red-600 text-white px-4 py-2 rounded-md hover:bg-red-700"
-                                    >
-                                        Delete
-                                    </button>
-                                </div>
-                            </div>
-
-                            {/* Summary Cards */}
-                            <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
-                                <div className="bg-blue-50 rounded-lg p-4 text-center">
-                                    <p className="text-sm text-blue-600">Salary</p>
-                                    <p className="text-2xl font-bold text-blue-900">
-                                        {formatMYR(planning.salary)}
-                                    </p>
-                                </div>
-                                <div className="bg-red-50 rounded-lg p-4 text-center">
-                                    <p className="text-sm text-red-600">Total Spending</p>
-                                    <p className="text-2xl font-bold text-red-900">
-                                        {formatMYR(planning.totals.spending)}
-                                    </p>
-                                </div>
-                                <div className="bg-green-50 rounded-lg p-4 text-center">
-                                    <p className="text-sm text-green-600">Remaining</p>
-                                    <p className="text-2xl font-bold text-green-900">
-                                        {formatMYR(planning.totals.balance)}
-                                    </p>
-                                </div>
-                                <div className="bg-purple-50 rounded-lg p-4 text-center">
-                                    <p className="text-sm text-purple-600">Savings</p>
-                                    <p className="text-2xl font-bold text-purple-900">
-                                        {formatMYR(planning.totals.savings)}
-                                    </p>
-                                </div>
-                            </div>
-
-                            {/* Sections */}
-                            <div className="space-y-4">
-                                {renderSection('Savings', planning.totals.savings, planning.sections?.savings, 'bg-green-50')}
-                                {renderSection('Commitments', planning.totals.commitments, planning.sections?.commitments, 'bg-blue-50')}
-                                {renderSection('Others', planning.totals.others, planning.sections?.others, 'bg-gray-50')}
-                            </div>
-
-                            <div className="mt-8">
-                                <Link
-                                    href="/planning"
-                                    className="text-indigo-600 hover:text-indigo-500"
-                                >
-                                    ← Back to Planning
-                                </Link>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </AppLayout>
-    );
+        </PageContainer>
+    </AppLayout>;
 }

--- a/resources/js/app-shell.test.tsx
+++ b/resources/js/app-shell.test.tsx
@@ -4,13 +4,21 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+const { pageState } = vi.hoisted(() => ({
+    pageState: {
+        locale: 'en',
+        translations: {},
+        flash: { message: null as string | null, success: null as string | null, error: null as string | null },
+    },
+}));
+
 vi.mock('@inertiajs/react', () => ({
     Link: ({ children, href, method: _method, as: _as, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { method?: string; as?: string }) => (
         <a href={String(href)} {...props}>{children}</a>
     ),
     usePage: () => ({
         url: '/planning',
-        props: { locale: 'en', translations: {} },
+        props: pageState,
     }),
 }));
 
@@ -36,7 +44,10 @@ const user = {
     updated_at: '2026-08-16T00:00:00+08:00',
 };
 
-afterEach(() => cleanup());
+afterEach(() => {
+    cleanup();
+    pageState.flash = { message: null, success: null, error: null };
+});
 
 describe('authenticated financial application shell', () => {
     it('renders exact financial values through the shared metric primitive', () => {
@@ -53,6 +64,9 @@ describe('authenticated financial application shell', () => {
 
         rerender(<FinancialNumber value={null} unavailableLabel="Balance unavailable" />);
         expect(screen.getByLabelText('Balance unavailable').textContent).toBe('RM —');
+
+        rerender(<FinancialNumber value="legacy-invalid" />);
+        expect(screen.getByLabelText('Unavailable').textContent).toBe('RM —');
     });
 
     it('only announces state panels when the caller requests live feedback', () => {
@@ -63,6 +77,19 @@ describe('authenticated financial application shell', () => {
 
         rerender(<StatePanel title="Save failed" description="Try again." tone="danger" announce="assertive" />);
         expect(screen.getByRole('alert').getAttribute('aria-live')).toBe('assertive');
+    });
+
+    it('announces server-provided success and error results after navigation', () => {
+        pageState.flash.success = 'August 2026 plan deleted.';
+        const { unmount } = render(<AppLayout user={user}><p>Plan content</p></AppLayout>);
+
+        expect(screen.getByRole('status').textContent).toContain('August 2026 plan deleted.');
+
+        unmount();
+        pageState.flash.success = null;
+        pageState.flash.error = 'The plan could not be deleted. Try again.';
+        render(<AppLayout user={user}><p>Plan content</p></AppLayout>);
+        expect(screen.getByRole('alert').textContent).toContain('could not be deleted');
     });
 
     it('exposes the approved desktop, tablet, and mobile navigation models', () => {

--- a/resources/js/app-shell.test.tsx
+++ b/resources/js/app-shell.test.tsx
@@ -8,7 +8,7 @@ const { pageState } = vi.hoisted(() => ({
     pageState: {
         locale: 'en',
         translations: {},
-        flash: { message: null as string | null, success: null as string | null, error: null as string | null },
+        flash: { message: null as string | null, success: null as string | null, warning: null as string | null, error: null as string | null },
     },
 }));
 
@@ -46,7 +46,7 @@ const user = {
 
 afterEach(() => {
     cleanup();
-    pageState.flash = { message: null, success: null, error: null };
+    pageState.flash = { message: null, success: null, warning: null, error: null };
 });
 
 describe('authenticated financial application shell', () => {
@@ -90,6 +90,15 @@ describe('authenticated financial application shell', () => {
         pageState.flash.error = 'The plan could not be deleted. Try again.';
         render(<AppLayout user={user}><p>Plan content</p></AppLayout>);
         expect(screen.getByRole('alert').textContent).toContain('could not be deleted');
+    });
+
+    it('announces a committed deletion with delayed cache refresh as a polite warning', () => {
+        pageState.flash.warning = 'August 2026 plan deleted. Planning lists may take up to five minutes to refresh.';
+        render(<AppLayout user={user}><p>Plan content</p></AppLayout>);
+
+        const status = screen.getByRole('status');
+        expect(status.textContent).toContain('plan deleted');
+        expect(status.className).toContain('app-flash-warning');
     });
 
     it('exposes the approved desktop, tablet, and mobile navigation models', () => {

--- a/resources/js/financial-summary.test.tsx
+++ b/resources/js/financial-summary.test.tsx
@@ -98,7 +98,7 @@ const partialPlan: Planning = {
     },
 };
 
-const props = { auth: { user }, flash: { message: null, success: null, error: null } };
+const props = { auth: { user }, flash: { message: null, success: null, warning: null, error: null } };
 
 afterEach(() => {
     cleanup();
@@ -153,7 +153,8 @@ describe('banking-style Planning summaries', () => {
             callbacks.onFinish();
         });
 
-        expect(screen.getByRole('alert').textContent).toContain('could not be deleted');
+        expect(screen.getByText('The plan could not be deleted. Try again.')).not.toBeNull();
+        expect(screen.queryByRole('alert')).toBeNull();
         expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Delete plan permanently' }));
     });
 

--- a/resources/js/financial-summary.test.tsx
+++ b/resources/js/financial-summary.test.tsx
@@ -1,0 +1,195 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { deleteRequest } = vi.hoisted(() => ({ deleteRequest: vi.fn() }));
+
+vi.mock('@inertiajs/react', () => ({
+    Head: () => null,
+    Link: ({ children, href, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => <a href={String(href)} {...props}>{children}</a>,
+    router: { delete: deleteRequest },
+}));
+
+vi.mock('./Layouts/AppLayout', () => ({
+    default: ({ children, header }: React.PropsWithChildren<{ header?: React.ReactNode }>) => <div>{header}{children}</div>,
+}));
+
+import Dashboard from './Pages/Dashboard/Index';
+import ExpensesShow from './Pages/Expenses/Show';
+import PlanningShow from './Pages/Planning/Show';
+import FinancialChartPanel from './Components/Financial/FinancialChartPanel';
+import { Planning, User } from './types';
+
+const user: User = {
+    user_id: '01PUBLICUSER',
+    name: 'Amina',
+    email: 'amina@example.test',
+    email_verified_at: '2026-08-16T00:00:00+08:00',
+    created_at: '2026-08-16T00:00:00+08:00',
+    updated_at: '2026-08-16T00:00:00+08:00',
+};
+
+const augustPlan: Planning = {
+    planning_id: '01AUGUSTPLAN',
+    month: 8,
+    year: 2026,
+    name: 'August 2026',
+    salary: '5000.00',
+    saving_rate: '20.00',
+    spending: '2700.00',
+    sections: {
+        savings: [{ item: 'Emergency fund', amount: '800.00' }],
+        commitments: [{ item: 'Rent', amount: '2000.00' }],
+        others: [{ item: 'Living', amount: '700.00' }],
+    },
+    totals: {
+        target_savings: '1000.00',
+        savings: '800.00',
+        commitments: '2000.00',
+        others: '700.00',
+        spending: '2700.00',
+        allocated: '3500.00',
+        balance: '1500.00',
+    },
+    created_at: '2026-08-16T00:00:00+08:00',
+    updated_at: '2026-08-16T00:00:00+08:00',
+};
+
+const julyPlan: Planning = {
+    ...augustPlan,
+    planning_id: '01JULYPLAN',
+    month: 7,
+    name: 'July 2026',
+    salary: '4800.00',
+    totals: { ...augustPlan.totals, allocated: '3300.00', balance: '1500.00' },
+};
+
+const zeroPlan: Planning = {
+    ...augustPlan,
+    planning_id: '01ZEROPLAN',
+    name: 'September 2026',
+    month: 9,
+    salary: '0.00',
+    saving_rate: '0.00',
+    spending: '0.00',
+    sections: { savings: [], commitments: [], others: [] },
+    totals: {
+        target_savings: '0.00', savings: '0.00', commitments: '0.00', others: '0.00',
+        spending: '0.00', allocated: '0.00', balance: '0.00',
+    },
+};
+
+const props = { auth: { user }, flash: { message: null, success: null, error: null } };
+
+afterEach(() => {
+    cleanup();
+    deleteRequest.mockReset();
+});
+
+describe('banking-style Planning summaries', () => {
+    it('renders the Planning hierarchy, exact chart alternatives, and allocation items', () => {
+        render(<PlanningShow {...props} planning={augustPlan} />);
+
+        const labels = ['Remaining planned balance', 'Monthly income', 'Savings allocation', 'Commitments', 'Other allocations'];
+        const figures = labels.map((label) => screen.getAllByText(label)[0]);
+        figures.slice(0, -1).forEach((figure, index) => expect(figure.compareDocumentPosition(figures[index + 1]) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy());
+        expect(screen.getByRole('table', { name: 'Allocation composition exact values' })).not.toBeNull();
+        expect(screen.getByRole('table', { name: 'Income and allocation exact values' })).not.toBeNull();
+        expect(screen.getByRole('table', { name: 'Savings target exact values' })).not.toBeNull();
+        expect(screen.getByText('Emergency fund')).not.toBeNull();
+        expect(screen.getAllByText('RM 800.00').length).toBeGreaterThan(0);
+    });
+
+    it('uses an accessible delete dialog with safe initial focus and focus return', () => {
+        render(<PlanningShow {...props} planning={augustPlan} />);
+
+        const trigger = screen.getByRole('button', { name: 'Delete plan' });
+        trigger.focus();
+        fireEvent.click(trigger);
+
+        const dialog = screen.getByRole('dialog', { name: 'Delete August 2026 plan?' });
+        const cancel = screen.getByRole('button', { name: 'Keep plan' });
+        expect(document.activeElement).toBe(cancel);
+
+        fireEvent.keyDown(dialog, { key: 'Escape' });
+        expect(screen.queryByRole('dialog')).toBeNull();
+        expect(document.activeElement).toBe(trigger);
+        expect(deleteRequest).not.toHaveBeenCalled();
+    });
+
+    it('announces delete progress, prevents duplicate requests, and restores context after failure', () => {
+        render(<PlanningShow {...props} planning={augustPlan} />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Delete plan' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Delete plan permanently' }));
+
+        expect(deleteRequest).toHaveBeenCalledTimes(1);
+        expect(deleteRequest.mock.calls[0][0]).toBe('/planning/01AUGUSTPLAN');
+        expect(screen.getByRole('status').textContent).toContain('Deleting August 2026 plan');
+        expect(screen.getByRole('button', { name: 'Deleting plan…' }).hasAttribute('disabled')).toBe(true);
+
+        const callbacks = deleteRequest.mock.calls[0][1] as { onError: () => void; onFinish: () => void };
+        act(() => { callbacks.onError(); callbacks.onFinish(); });
+
+        expect(screen.getByRole('alert').textContent).toContain('could not be deleted');
+        expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Delete plan permanently' }));
+    });
+
+    it('labels Expenses as a read-only projection and never offers deletion', () => {
+        render(<ExpensesShow {...props} planning={augustPlan} />);
+
+        expect(screen.getAllByText('Expense projection').length).toBeGreaterThan(0);
+        expect(screen.getByText(/planned allocation breakdown/i)).not.toBeNull();
+        expect(screen.queryByRole('button', { name: /delete/i })).toBeNull();
+        expect(screen.getByRole('link', { name: 'Open full plan' }).getAttribute('href')).toBe('/planning/01AUGUSTPLAN');
+    });
+
+    it('shows an explicit selected period and an exact multi-period trend on Dashboard', () => {
+        render(<Dashboard {...props} plannings={[augustPlan, julyPlan]} />);
+
+        expect(screen.getByText('Selected plan: August 2026')).not.toBeNull();
+        expect(screen.queryByText(/this month/i)).toBeNull();
+        expect(screen.getByRole('table', { name: 'Planned trend exact values' })).not.toBeNull();
+        expect(screen.getAllByText('July 2026').length).toBeGreaterThan(0);
+    });
+
+    it('shows a purposeful empty Dashboard and hides an ineligible one-period trend', () => {
+        const { rerender } = render(<Dashboard {...props} plannings={[]} />);
+
+        expect(screen.getByText('Create your first monthly plan')).not.toBeNull();
+        expect(screen.getByRole('link', { name: 'Create a plan' }).getAttribute('href')).toBe('/planning/create');
+        expect(screen.queryByRole('table')).toBeNull();
+
+        rerender(<Dashboard {...props} plannings={[augustPlan]} />);
+        expect(screen.queryByRole('table', { name: 'Planned trend exact values' })).toBeNull();
+        expect(screen.getByText('Selected plan: August 2026')).not.toBeNull();
+    });
+
+    it('keeps zero denominators unavailable and exact instead of fabricating percentages', () => {
+        render(<PlanningShow {...props} planning={zeroPlan} />);
+
+        expect(screen.getByText('No allocations added')).not.toBeNull();
+        expect(screen.getByText('No savings target set')).not.toBeNull();
+        expect(screen.getAllByText('Percentage unavailable').length).toBeGreaterThan(0);
+        expect(document.body.textContent).not.toMatch(/NaN|Infinity/);
+    });
+
+    it('states the exact amount when savings exceed the target', () => {
+        const overTargetPlan = {
+            ...augustPlan,
+            totals: { ...augustPlan.totals, savings: '1200.00', allocated: '3900.00', balance: '1100.00' },
+        };
+
+        render(<PlanningShow {...props} planning={overTargetPlan} />);
+
+        expect(screen.getByText('Above savings target by RM 200.00')).not.toBeNull();
+    });
+
+    it('keeps the exact-value fallback when a chart visual is unavailable', () => {
+        render(<FinancialChartPanel title="Comparison" description="Exact fallback"><p>Exact values</p></FinancialChartPanel>);
+
+        expect(screen.getByRole('status').textContent).toContain('Visual unavailable');
+        expect(screen.getByText('Exact values')).not.toBeNull();
+    });
+});

--- a/resources/js/financial-summary.test.tsx
+++ b/resources/js/financial-summary.test.tsx
@@ -80,6 +80,24 @@ const zeroPlan: Planning = {
     },
 };
 
+const negativePlan: Planning = {
+    ...augustPlan,
+    planning_id: '01NEGATIVEPLAN',
+    totals: { ...augustPlan.totals, allocated: '5100.00', balance: '-100.00' },
+};
+
+const partialPlan: Planning = {
+    ...augustPlan,
+    planning_id: '01PARTIALPLAN',
+    totals: {
+        ...augustPlan.totals,
+        target_savings: 'unavailable',
+        savings: 'unavailable',
+        allocated: 'unavailable',
+        balance: 'unavailable',
+    },
+};
+
 const props = { auth: { user }, flash: { message: null, success: null, error: null } };
 
 afterEach(() => {
@@ -129,8 +147,11 @@ describe('banking-style Planning summaries', () => {
         expect(screen.getByRole('status').textContent).toContain('Deleting August 2026 plan');
         expect(screen.getByRole('button', { name: 'Deleting plan…' }).hasAttribute('disabled')).toBe(true);
 
-        const callbacks = deleteRequest.mock.calls[0][1] as { onError: () => void; onFinish: () => void };
-        act(() => { callbacks.onError(); callbacks.onFinish(); });
+        const callbacks = deleteRequest.mock.calls[0][1] as { onSuccess: (page: { props: { flash: { error: string } } }) => void; onFinish: () => void };
+        act(() => {
+            callbacks.onSuccess({ props: { flash: { error: 'The plan could not be deleted. Try again.' } } });
+            callbacks.onFinish();
+        });
 
         expect(screen.getByRole('alert').textContent).toContain('could not be deleted');
         expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Delete plan permanently' }));
@@ -172,7 +193,29 @@ describe('banking-style Planning summaries', () => {
         expect(screen.getByText('No allocations added')).not.toBeNull();
         expect(screen.getByText('No savings target set')).not.toBeNull();
         expect(screen.getAllByText('Percentage unavailable').length).toBeGreaterThan(0);
+        expect(screen.queryByRole('status')).toBeNull();
         expect(document.body.textContent).not.toMatch(/NaN|Infinity/);
+    });
+
+    it('shows partial legacy values as unavailable instead of inventing zero', () => {
+        render(<PlanningShow {...props} planning={partialPlan} />);
+
+        expect(screen.getByText('Allocation comparison unavailable.')).not.toBeNull();
+        expect(screen.getAllByText('Income comparison unavailable.').length).toBeGreaterThan(0);
+        expect(screen.getByText('Savings target comparison unavailable.')).not.toBeNull();
+        expect(screen.getAllByLabelText('Unavailable').length).toBeGreaterThan(0);
+        expect(screen.queryByText('Target difference')).toBeNull();
+    });
+
+    it('marks negative legacy remaining values as exact over-allocation in summaries and trends', () => {
+        const { rerender } = render(<PlanningShow {...props} planning={negativePlan} />);
+
+        expect(screen.getAllByText('Over allocated by RM 100.00').length).toBeGreaterThan(0);
+        expect(document.querySelector('.financial-hero.state-danger')).not.toBeNull();
+        expect(document.querySelector('.over-allocation-marker')).not.toBeNull();
+
+        rerender(<Dashboard {...props} plannings={[negativePlan, julyPlan]} />);
+        expect(document.querySelector('.trend-over-allocation')).not.toBeNull();
     });
 
     it('states the exact amount when savings exceed the target', () => {
@@ -186,10 +229,17 @@ describe('banking-style Planning summaries', () => {
         expect(screen.getByText('Above savings target by RM 200.00')).not.toBeNull();
     });
 
+    it('states the exact direction when savings remain below target', () => {
+        render(<PlanningShow {...props} planning={augustPlan} />);
+
+        expect(screen.getByText('Below savings target by RM 200.00')).not.toBeNull();
+    });
+
     it('keeps the exact-value fallback when a chart visual is unavailable', () => {
         render(<FinancialChartPanel title="Comparison" description="Exact fallback"><p>Exact values</p></FinancialChartPanel>);
 
-        expect(screen.getByRole('status').textContent).toContain('Visual unavailable');
+        expect(screen.getByText('Visual unavailable. Exact values remain below.')).not.toBeNull();
+        expect(screen.queryByRole('status')).toBeNull();
         expect(screen.getByText('Exact values')).not.toBeNull();
     });
 });

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -49,6 +49,7 @@ export interface PageProps {
     flash: {
         message: string | null;
         success: string | null;
+        warning: string | null;
         error: string | null;
     };
     locale?: string;

--- a/resources/js/utils/financialPresentation.ts
+++ b/resources/js/utils/financialPresentation.ts
@@ -1,0 +1,48 @@
+import { formatSen, parseMoney } from './money';
+
+export interface PresentationRatio {
+    basisPoints: bigint | null;
+    label: string | null;
+    width: number;
+}
+
+export function signedMoney(value: string | null | undefined): bigint | null {
+    if (!value) return null;
+    const negative = value.startsWith('-');
+    const parsed = parseMoney(negative ? value.slice(1) : value);
+
+    return parsed === null ? null : (negative ? -parsed : parsed);
+}
+
+export function presentationRatio(value: string | null | undefined, total: string | null | undefined): PresentationRatio {
+    const numerator = signedMoney(value);
+    const denominator = signedMoney(total);
+
+    if (numerator === null || denominator === null || denominator <= 0n || numerator < 0n) {
+        return { basisPoints: null, label: null, width: 0 };
+    }
+
+    const basisPoints = ((numerator * 10_000n) + (denominator / 2n)) / denominator;
+    const percent = `${basisPoints / 100n}.${(basisPoints % 100n).toString().padStart(2, '0')}`
+        .replace(/\.00$/, '')
+        .replace(/(\.\d)0$/, '$1');
+
+    return {
+        basisPoints,
+        label: `${percent}%`,
+        width: Number(basisPoints > 10_000n ? 10_000n : basisPoints) / 100,
+    };
+}
+
+export function moneyDifference(value: string, reference: string): string | null {
+    const left = signedMoney(value);
+    const right = signedMoney(reference);
+    return left === null || right === null ? null : formatSen(left - right);
+}
+
+export function magnitudeWidth(value: string, maximum: bigint): number {
+    const parsed = signedMoney(value);
+    if (parsed === null || parsed <= 0n || maximum <= 0n) return 0;
+
+    return Number(((parsed * 10_000n) / maximum)) / 100;
+}

--- a/tests/Feature/Planning/PlanningAuthorizationTest.php
+++ b/tests/Feature/Planning/PlanningAuthorizationTest.php
@@ -2,8 +2,11 @@
 
 use App\Models\User;
 use App\Modules\Planning\Models\Planning;
+use App\Modules\Planning\Services\PlanningCache;
 use App\Modules\Planning\Services\PlanningService;
+use Illuminate\Contracts\Cache\Repository;
 use Inertia\Testing\AssertableInertia as Assert;
+use Mockery\MockInterface;
 
 test('owners can view planning through its public id without numeric identifiers', function () {
     $owner = User::factory()->create();
@@ -62,6 +65,27 @@ test('a failed owner deletion returns to the plan with an announced error', func
         ->assertSessionHas('error', 'The plan could not be deleted. Try again.');
 
     expect($planning->fresh()->trashed())->toBeFalse();
+});
+
+test('a cache failure after deletion reports the committed result without inviting a retry', function () {
+    $owner = User::factory()->create();
+    $planning = Planning::factory()->for($owner)->create();
+    $name = $planning->name;
+
+    $repository = $this->mock(Repository::class, function (MockInterface $mock): void {
+        $mock->shouldReceive('forget')
+            ->once()
+            ->andThrow(new RuntimeException('cache unavailable'));
+    });
+    $this->app->instance(PlanningCache::class, new PlanningCache($repository));
+
+    $this->actingAs($owner)
+        ->delete(route('planning.destroy', $planning->planning_id))
+        ->assertRedirect(route('planning.index'))
+        ->assertSessionHas('warning', "{$name} plan deleted. Planning lists may take up to five minutes to refresh.")
+        ->assertSessionMissing('error');
+
+    expect($planning->fresh()->trashed())->toBeTrue();
 });
 
 test('planning projections expose only owned records through public identifiers', function (string $routeName, string $component) {

--- a/tests/Feature/Planning/PlanningAuthorizationTest.php
+++ b/tests/Feature/Planning/PlanningAuthorizationTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\User;
 use App\Modules\Planning\Models\Planning;
+use App\Modules\Planning\Services\PlanningService;
 use Inertia\Testing\AssertableInertia as Assert;
 
 test('owners can view planning through its public id without numeric identifiers', function () {
@@ -40,9 +41,27 @@ test('owners can delete their planning through its public id', function () {
 
     $this->actingAs($owner)
         ->delete(route('planning.destroy', $planning->planning_id))
-        ->assertRedirect(route('planning.index'));
+        ->assertRedirect(route('planning.index'))
+        ->assertSessionHas('success', "{$planning->name} plan deleted.");
 
     expect($planning->fresh()->trashed())->toBeTrue();
+});
+
+test('a failed owner deletion returns to the plan with an announced error', function () {
+    $owner = User::factory()->create();
+    $planning = Planning::factory()->for($owner)->create();
+    $this->mock(PlanningService::class)
+        ->shouldReceive('delete')
+        ->once()
+        ->andThrow(new RuntimeException('database unavailable'));
+
+    $this->actingAs($owner)
+        ->from(route('planning.show', $planning->planning_id))
+        ->delete(route('planning.destroy', $planning->planning_id))
+        ->assertRedirect(route('planning.show', $planning->planning_id))
+        ->assertSessionHas('error', 'The plan could not be deleted. Try again.');
+
+    expect($planning->fresh()->trashed())->toBeFalse();
 });
 
 test('planning projections expose only owned records through public identifiers', function (string $routeName, string $component) {


### PR DESCRIPTION
## Summary

Implement the owner-approved banking-style Planning experience across Dashboard, Planning detail, and the read-only Expenses projection using #63's authoritative exact values and #123's accessible application shell.

Closes #124
Refs #63
Refs #123
Refs #125

## Changes

- Added shared financial summary, chart panel, planned trend, allocation section, and accessible delete-dialog components.
- Preserved the approved figure order: remaining planned balance, monthly income, savings allocation/target, commitments, other allocations, then the lower-priority total allocation roll-up.
- Added CSS-only allocation composition, income/allocation, savings-target, category magnitude, and multi-period planned-trend visuals; every chart retains an exact-value table and does not depend on color for meaning.
- Made zero-income, zero-target, and partial legacy values explicitly unavailable; capped only visual widths above 100%; and retained exact over-target and over-allocation amounts.
- Made Dashboard name the selected persisted plan explicitly, show a purposeful no-plan state, and hide the trend until at least two periods exist.
- Made Expenses unambiguously a read-only planned allocation projection rather than a transaction ledger.
- Replaced direct plan deletion with a period-named modal dialog, safe initial focus, containment, Escape/cancel, pending announcement, duplicate-request prevention, and public-ID deletion through the existing authorized endpoint.
- Connected deletion to real server result flashes: success identifies the deleted period, service failures disclose no exception detail, global announcements use the appropriate live-region urgency, and same-page failures restore dialog context.
- Kept committed database deletion authoritative when post-commit cache invalidation fails: the exception is reported, the user receives a polite five-minute stale-list warning, and the UI never invites a destructive retry.
- Kept presentation-only percentages, differences, and chart magnitudes in one tested BigInt/sen helper; page components do not redefine #63's financial formulas or parse floats.
- Recorded the implemented v2.1.4 target in the canonical Planning summary specification.

## Validation

- After preservation-checked rebase onto merged PR #127, `composer check` passed at exact head `c244b8d`: Pint, Larastan 83/83, 125 backend tests/586 assertions, 42 frontend tests, TypeScript, 814-module production build, and zero Composer/npm vulnerabilities.
- Focused coverage includes hierarchy, exact chart alternatives, negative/partial/unavailable legacy states, allocation items, delete cancel/pending/real-result/focus behavior, global flash announcements, Expenses projection language, selected period/trend eligibility, empty state, zero denominators, directional target differences, and visual fallback.
- Codex Security diff scan `22ec6ca7-c701-40e7-ba5f-ed76dfbb9ebd`: complete eighteen-item exact-head source inventory plus Laravel destroy-route, binding, policy, service, post-commit cache, Inertia flash, payload, and money-parser controls; zero reportable findings.
- `git diff --check`: passed.
- Hosted GitHub Actions remain disabled under the approved zero-cost policy.

## Accessibility and responsive behavior

- Visual charts are redundant and hidden from assistive technology; labelled exact-value tables remain primary alternatives.
- Graph categories keep fixed labels/order and distinct fills/patterns, so meaning is not color-only.
- Tables scroll inside their panels without creating page-level horizontal overflow at 320 CSS px.
- DOM order remains the approved mobile-first hierarchy; tablet/desktop grids change placement without changing reading order.
- Inertia page transitions retain the existing global progress indication; pages do not render invented loading figures before authoritative props arrive.

## Risks and rollback

- Primary risks are visual crowding with long allocation lists and regressions in destructive focus behavior.
- Roll back this focused PR to restore the prior detail pages; #63 money persistence/calculations and #123 shell remain intact.
- No migration, environment, dependency, queue, public API, route, authorization-policy, or server-side financial-calculation change is included; the controller change is limited to safe deletion result redirects and flashes.

## Stack

- Re-anchored directly to `v2.1.4` after PR #126 and PR #127 merged; the original reviewed #124 tree was preserved before the focused cache-boundary correction.
